### PR TITLE
Issue 043

### DIFF
--- a/lib/home/search_page_controller.dart
+++ b/lib/home/search_page_controller.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../screens/search_groups_screen.dart';
 import '../screens/search_people_screen.dart';
+import '../screens/search_events_screen.dart';
 
 class SearchPageController extends StatefulWidget {
   const SearchPageController({Key? key}) : super(key: key);
@@ -31,7 +32,8 @@ class _SearchPageControllerState extends State<SearchPageController> {
       controller: _pageController,
       children: [
         SearchGroupsScreen(pageController: _pageController),
-        SearchPeopleScreen(pageController: _pageController,),
+        SearchPeopleScreen(pageController: _pageController),
+        SearchEventsScreen(pageController: _pageController),
       ],
     );
   }

--- a/lib/model/event_card_view.dart
+++ b/lib/model/event_card_view.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+
+import 'event_db.dart';
+
+class EventCardView extends StatelessWidget {
+  const EventCardView({Key? key, required this.id}) : super(key: key);
+
+  final String id;
+
+  @override
+  Widget build(BuildContext context) {
+    Event thisEvent = eventsDB.getEventById(id);
+
+    return Padding(
+      padding: const EdgeInsets.all(3.5),
+      child: Card(
+        elevation: 8,
+        child: Column(
+          children: [
+            ListTile(
+              title: Text(
+                thisEvent.eventName,
+                style: Theme.of(context).textTheme.titleLarge,
+              )
+            ),
+            Padding(
+              padding: const EdgeInsets.only(left: 15.0, top: 2.0),
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  "${thisEvent.eventLocation} | ${thisEvent.eventDate}",
+                ),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.only(left: 15.0, top: 2.0),
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  thisEvent.eventDescription,
+                ),
+              ),
+            ),
+            const SizedBox(height: 10)
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/model/event_card_widget.dart
+++ b/lib/model/event_card_widget.dart
@@ -1,0 +1,25 @@
+import 'package:connectuni/model/event_card_view.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+class EventCardWidget extends StatelessWidget {
+  const EventCardWidget({Key? key, required this.eventId}) : super(key: key);
+
+  final String eventId;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () {
+        /*
+        Navigator.push(
+          context,
+          CupertinoPageRoute(
+              builder: (context) => EventInfo(id: eventId)
+          ),
+         */
+      },
+      child: EventCardView(id: eventId),
+    );
+  }
+}

--- a/lib/model/event_db.dart
+++ b/lib/model/event_db.dart
@@ -1,0 +1,116 @@
+/**
+ * Generic outline of the different events that will be described by each page.
+ */
+
+///The data associated with events.
+class Event {
+  Event({
+    required this.eventId, //Ex. 'event-001'
+    required this.eventName, // Ex. 'Pizza Party'
+    required this.eventIcon, //Ex. 'pizza.png'
+    required this.eventLocation, //Ex. 'Hamilton Library'
+    required this.eventDescription, //Ex. 'Come join us for a pizza party!'
+    required this.eventDate, //Ex. DateTime(2023, 10, 13, 12, 30)
+    required this.groupId,  //Ex. 'group-001'
+    required this.userIds,  //Ex. ['user-001', 'user-002', 'user-003']
+  });
+
+  final String eventId;
+  final String eventName;
+  String eventIcon;
+  String eventLocation;
+  String eventDescription;
+  final DateTime eventDate;
+  final String groupId;
+  List<String> userIds;
+
+  ///Setter methods:
+  //Setter method that updates the Event Icon.
+  void updateEventIcon(String newIcon) {
+    eventIcon = newIcon;
+  }
+  //Setter method that adds a user to the event.
+  void addUser(String userId) {
+    userIds.add(userId);
+  }
+  //Setter method that removes a user from the event.
+  void removeUser(String userId) {
+    userIds.remove(userId);
+  }
+  //Setter method that updates the event description.
+  void updateEventDescription(String newDescription) {
+    eventDescription = newDescription;
+  }
+  //Setter method that updates the event location.
+  void updateEventLocation(String newLocation) {
+    eventLocation = newLocation;
+  }
+  ///Getter methods:
+    bool isUserInEvent(String userId) {
+      return userIds.contains(userId);
+    }
+}
+
+///Provides access to and operations on all defined groups.
+class EventsDB {
+  //Example data for events.
+  List<Event> allEvents = [
+    Event(
+      eventId: 'event-001',
+      eventName: 'ICS 466 Pizza Party',
+      eventIcon: '',
+      eventLocation: 'Keller 102',
+      eventDescription: 'Come join us for a pizza party!',
+      eventDate: DateTime(2023, 10, 13, 12, 30),
+      groupId: 'group-001',
+      userIds: ['user-001', 'user-002', 'user-003'],
+    ),
+    Event(
+      eventId: 'event-002',
+      eventName: 'ICS 332 Study Session',
+      eventIcon: '',
+      eventLocation: 'ICSpace',
+      eventDescription: 'Study session for the upcoming ICS 332 Quiz. Come join us!',
+      eventDate: DateTime(2023, 10, 9, 9, 00),
+      groupId: 'group-002',
+      userIds: ['user-001'],
+    ),
+    Event(
+      eventId: 'event-003',
+      eventName: 'MATH 307 Bowling Outing',
+      eventIcon: '',
+      eventLocation: 'Aiea Bowl',
+      eventDescription: 'Annual Math 307 Bowling competition. Any experience is welcome! Five dollar entrance fee though.',
+      eventDate: DateTime(2023, 10, 25, 18, 30),
+      groupId: 'group-003',
+      userIds: ['user-002', 'user-003'],
+    ),
+  ];
+  ///SETTER METHODS:
+
+  //Setter methods that add and remove events respectively.
+  void addEvent(Event newEvent) {
+    allEvents.add(newEvent);
+  }
+  void removeEvent(Event event) {
+    allEvents.remove(event);
+  }
+  ///GETTER METHODS:
+  //Getter methods that return events based on their event ID, name, and group ID respectively.
+  Event getEventById(String eventId) {
+    return allEvents.firstWhere((event) => event.eventId == eventId);
+  }
+  Event getEventByName(String eventName) {
+    return allEvents.firstWhere((event) => event.eventName == eventName);
+  }
+  List<Event> getEventsByGroupId(String groupId) {
+    return allEvents.where((event) => event.groupId == groupId).toList();
+  }
+
+  //Getter method that returns all events.
+  List<Event> getAllEvents() {
+    return allEvents;
+  }//loadGroups
+} //Groups Repository
+
+EventsDB eventsDB = EventsDB();

--- a/lib/model/group_chat_widget.dart
+++ b/lib/model/group_chat_widget.dart
@@ -33,10 +33,7 @@ class _GroupChatWidgetState extends State<GroupChatWidget> {
           ),
         );
       },
-      child: Container(
-        padding: const EdgeInsets.all(8.0),
-        child: GroupCardView(id: groupData.groupId),
-      ),
+      child: GroupCardView(id: groupData.groupId)
     );
   }
 }

--- a/lib/screens/search_events_screen.dart
+++ b/lib/screens/search_events_screen.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:multi_select_flutter/multi_select_flutter.dart';
+
+import '../model/event_db.dart';
+import '../model/event_card_view.dart';
+
+class SearchEventsScreen extends StatefulWidget {
+  const SearchEventsScreen({Key? key, required this.pageController}) : super(key: key);
+
+  static const String routeName = '/search_events';
+  final PageController pageController;
+
+  @override
+  State<SearchEventsScreen> createState() => _SearchEventsScreenState();
+}
+
+class _SearchEventsScreenState extends State<SearchEventsScreen> {
+  final _items = eventsDB.getAllEvents().map((eName) => MultiSelectItem(eName, eName.eventName)).toList();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Search for Events'),
+        actions: <Widget>[
+          IconButton(
+            icon: const Icon(
+              Icons.arrow_back_ios,
+              semanticLabel: 'Search for groups',
+            ),
+            onPressed: () {
+              widget.pageController.animateToPage(1, duration: const Duration(milliseconds: 300), curve: Curves.easeInOut);
+            },
+          ),
+        ],
+      ),
+      body: SingleChildScrollView(
+        child: Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: MultiSelectDialogField(
+                items: _items,
+                selectedColor: Colors.blue,
+                decoration: BoxDecoration(
+                  color: Colors.blue.withOpacity(0.1),
+                  borderRadius: const BorderRadius.all(Radius.circular(40)),
+                  border: Border.all(
+                    color: Colors.blue,
+                    width: 2,
+                  ),
+                ),
+                buttonIcon: const Icon(
+                  Icons.filter,
+                  color: Colors.blue,
+                ),
+                buttonText: const Text(
+                  "Filter by:",
+                  style: TextStyle(
+                    color: Colors.blue,
+                    fontSize: 16,
+                  ),
+                ),
+                onConfirm: (results) {
+                  // TODO: Filter the events list
+                },
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: SearchAnchor(
+                builder: (BuildContext context, SearchController controller) {
+                  return SearchBar(
+                    controller: controller,
+                    onTap: () {
+                      controller.openView();
+                    },
+                    onChanged: (_) {
+                      controller.openView();
+                    },
+                    hintText: "Search...",
+                    leading: const Icon(Icons.search),
+                  );
+                },
+                suggestionsBuilder: (BuildContext context, SearchController controller) {
+                  return List<ListTile>.generate(5, (int index) {
+                    final String item = 'item $index';
+                    return ListTile(
+                      title: Text(item),
+                      onTap: () {
+                        controller.closeView(item);
+                      },
+                    );
+                  });
+                },
+              ),
+            ),
+            const Text(
+              'Events',
+              textAlign: TextAlign.left,
+            ),
+            ...eventsDB
+            .getAllEvents()
+            .map((eid) => EventCardView(id: eid.eventId))
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/search_groups_screen.dart
+++ b/lib/screens/search_groups_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:multi_select_flutter/multi_select_flutter.dart';
-import 'package:connectuni/model/group.dart';
 
+import '../model/group.dart';
 import '../model/group_card_view.dart';
 
 
@@ -26,13 +26,13 @@ class _SearchGroupsScreenState extends State<SearchGroupsScreen> {
         actions: <Widget>[
           IconButton(
             icon: const Icon(
-              Icons.person_search,
-              semanticLabel: 'Search for people',
+              Icons.arrow_forward_ios,
+              semanticLabel: 'Search for events',
             ),
             onPressed: () {
               widget.pageController.animateToPage(1, duration: const Duration(milliseconds: 300), curve: Curves.easeInOut);
             },
-          )
+          ),
         ],
       ),
       body: SingleChildScrollView(
@@ -64,7 +64,7 @@ class _SearchGroupsScreenState extends State<SearchGroupsScreen> {
                   ),
                 ),
                 onConfirm: (results) {
-                  //_selectedAnimals = results;
+                  // TODO: Filter groups by results
                 },
               ),
             ),

--- a/lib/screens/search_people_screen.dart
+++ b/lib/screens/search_people_screen.dart
@@ -26,11 +26,20 @@ class _SearchPeopleScreenState extends State<SearchPeopleScreen> {
         actions: <Widget>[
           IconButton(
             icon: const Icon(
-                Icons.search,
+                Icons.arrow_back_ios,
                 semanticLabel: 'Search for groups',
             ),
             onPressed: () {
               widget.pageController.animateToPage(0, duration: const Duration(milliseconds: 300), curve: Curves.easeInOut);
+            },
+          ),
+          IconButton(
+            icon: const Icon(
+              Icons.arrow_forward_ios,
+              semanticLabel: 'Search for events',
+            ),
+            onPressed: () {
+              widget.pageController.animateToPage(2, duration: const Duration(milliseconds: 300), curve: Curves.easeInOut);
             },
           ),
         ],

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.2"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -103,10 +103,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.9.1"
   multi_select_flutter:
     dependency: "direct main"
     description:
@@ -140,18 +140,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.11.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
@@ -172,10 +172,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.6.0"
   vector_math:
     dependency: transitive
     description:
@@ -188,9 +188,9 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: ccbbfbf29732ee1b391c4c6d13e7032d851f675f47365e81904e4c6fd669c854
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.2-beta"
+    version: "0.1.4-beta"
 sdks:
-  dart: ">=3.2.0-194.0.dev <4.0.0"
+  dart: ">=3.1.2 <4.0.0"


### PR DESCRIPTION
Added Search for events page under search tab. Changed icons in the appBar of the search tab to be arrows to navigate between the two pages. Swiping between search pages is still available. Only lists all events in the eventsDB.

## Search for Events Page:
![image](https://github.com/ConnectUni/connectuni/assets/89962623/17fd4394-e644-4ef9-a3df-7b18c028e3a4)
