### PR TITLE
Issue 071: Other User Profile

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -10,7 +10,7 @@ import 'home/home.dart';
 import 'screens/chatpage.dart';
 import 'screens/groupinfo.dart';
 import 'screens/settings.dart';
-import 'screens/profile.dart';
+import 'screens/current_user_profile.dart';
 import 'screens/search_people_screen.dart';
 import 'screens/search_groups_screen.dart';
 
@@ -44,7 +44,7 @@ class ConnectUniApp extends StatelessWidget {
         '/groupinfo': (BuildContext context) => const GroupInfo(id: ''),
         '/eventinfo': (BuildContext context) => const EventInfoScreen(id: '',),
         '/conversations': (BuildContext context) => const ChatPage(),
-        '/profile': (BuildContext context) => ProfilePage(),
+        '/profile': (BuildContext context) => const CurrentUserProfilePage(),
         '/friendslist': (BuildContext context) => const FriendsList(),
       },
     );

--- a/lib/components/user_card_search.dart
+++ b/lib/components/user_card_search.dart
@@ -1,3 +1,4 @@
+import 'package:connectuni/screens/other_user_profile.dart';
 import 'package:flutter/material.dart';
 
 import 'package:connectuni/model/user.dart';
@@ -31,6 +32,12 @@ class UserCardSearch extends StatelessWidget {
                   icon: const Icon(Icons.message),
                   onPressed: () {
                     // TODO Add functionality to message user
+                    Navigator.push(
+                        context,
+                        MaterialPageRoute(builder: (context) {
+                          return OtherUserProfile(uid: thisUser.uid);
+                        })
+                    );
                   },
                 ),
               ),

--- a/lib/components/user_card_widget.dart
+++ b/lib/components/user_card_widget.dart
@@ -7,24 +7,23 @@ import '../model/userList.dart';
 import '../screens/other_user_profile.dart';
 
 class UserCardWidget extends StatelessWidget {
-  const UserCardWidget({Key? key, required this.id}) : super(key: key);
+  const UserCardWidget({Key? key, required this.user}) : super(key: key);
 
-  final String id;
+  final User user;
 
   @override
   Widget build(BuildContext context) {
-    User thisUser = usersDB.getUserByID(id);
 
     return GestureDetector(
       onTap: () {
         Navigator.push(
           context,
           CupertinoPageRoute(
-              builder: (context) => OtherUserProfile(uid: thisUser.uid)
+              builder: (context) => OtherUserProfile(uid: user.uid)
           )
         );
       },
-      child: UserCardSearch(name: thisUser.displayName)
+      child: UserCardSearch(name: user.displayName),
     );
   }
 }

--- a/lib/components/user_card_widget.dart
+++ b/lib/components/user_card_widget.dart
@@ -1,0 +1,30 @@
+import 'package:connectuni/components/user_card_search.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+import '../model/user.dart';
+import '../model/userList.dart';
+import '../screens/other_user_profile.dart';
+
+class UserCardWidget extends StatelessWidget {
+  const UserCardWidget({Key? key, required this.id}) : super(key: key);
+
+  final String id;
+
+  @override
+  Widget build(BuildContext context) {
+    User thisUser = usersDB.getUserByID(id);
+
+    return GestureDetector(
+      onTap: () {
+        Navigator.push(
+          context,
+          CupertinoPageRoute(
+              builder: (context) => OtherUserProfile(uid: thisUser.uid)
+          )
+        );
+      },
+      child: UserCardSearch(name: thisUser.displayName)
+    );
+  }
+}

--- a/lib/model/userList.dart
+++ b/lib/model/userList.dart
@@ -189,6 +189,10 @@ final List<User> mockUsers = [
     ],
     ['Computer Science', 'Mathematics'],
   ),
+  friend1,
+  friend2,
 ];
 
 UserList usersDB = UserList(mockUsers);
+
+User currentUser = usersDB.getUserByID('user-001');

--- a/lib/screens/current_user_profile.dart
+++ b/lib/screens/current_user_profile.dart
@@ -1,5 +1,4 @@
 import 'package:connectuni/model/user.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:connectuni/model/userList.dart';
 import 'package:connectuni/model/group.dart';

--- a/lib/screens/current_user_profile.dart
+++ b/lib/screens/current_user_profile.dart
@@ -1,21 +1,23 @@
 import 'package:connectuni/model/user.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:connectuni/model/userList.dart';
 import 'package:connectuni/model/group.dart';
 
-/**
- *  Profile Page that the User sees when they click the Navbar Profile icon.
- */
+import 'friendslist.dart';
 
-class ProfilePage extends StatefulWidget {
-  ProfilePage({
+///  Profile Page that the User sees when they click the Navbar Profile icon.
+
+class CurrentUserProfilePage extends StatefulWidget {
+  const CurrentUserProfilePage({
     super.key,
   });
 
-  State<ProfilePage> createState() => _ProfilePageState();
+  @override
+  State<CurrentUserProfilePage> createState() => _CurrentUserProfilePageState();
 }
 
-class _ProfilePageState extends State<ProfilePage> {
+class _CurrentUserProfilePageState extends State<CurrentUserProfilePage> {
   int _selectedIndex = 0;
 
   void _onItemTapped(int index) {
@@ -40,8 +42,12 @@ class _ProfilePageState extends State<ProfilePage> {
               semanticLabel: 'friends list',
             ),
             onPressed: () {
-              //Routes to the Friends List Page.
-              Navigator.restorablePushNamed(context, '/friendslist', arguments: '/');
+              Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (context) {
+                    return const FriendsList();
+                  })
+              );
             },
           ),
           IconButton(
@@ -57,56 +63,55 @@ class _ProfilePageState extends State<ProfilePage> {
         ],
       ),
       body: ListView(
-        padding: EdgeInsets.all(20.0),
+        padding: const EdgeInsets.all(20.0),
         children: [
-          Container(
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-              children: [
-                Column(
-                  children: [CircleAvatar(
-                    radius: 50,
-                    backgroundImage: AssetImage(currentUser.pfp),
-                  ),
-            ]
-                ),
-                Expanded(child: Column(
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: [
+              Column(
                   children: [
-                    Text(
-                      currentUser.displayName,
-                      style: const TextStyle(
-                        fontSize: 23,
-                        fontWeight: FontWeight.bold,
-                      ),
+                    CircleAvatar(
+                      radius: 50,
+                      backgroundImage: AssetImage(currentUser.pfp),
                     ),
-                    Text(
-                      'Major: ${currentUser.major}',
-                      style: const TextStyle(
-                        fontSize: 15,
-                      ),
+                  ]
+              ),
+              Expanded(child: Column(
+                children: [
+                  Text(
+                    currentUser.displayName,
+                    style: const TextStyle(
+                      fontSize: 23,
+                      fontWeight: FontWeight.bold,
                     ),
-                    Text(
-                      'Projected Grad: ${currentUser.projectedGraduation}',
-                      style: const TextStyle(
-                        fontSize: 15,
-                      ),
+                  ),
+                  Text(
+                    'Major: ${currentUser.major}',
+                    style: const TextStyle(
+                      fontSize: 15,
                     ),
-                    Padding(
-                      padding: const EdgeInsets.all(10.0),
-                      child: TextButton(
-                        onPressed: null,
-                        style: ButtonStyle(
-                          backgroundColor: MaterialStateProperty.all<Color>(Colors.green),
-                          foregroundColor: MaterialStateProperty.all<Color>(Colors.white),
-                        ),
-                        child: const Text('Edit Profile'),
-                      ),
+                  ),
+                  Text(
+                    'Projected Grad: ${currentUser.projectedGraduation}',
+                    style: const TextStyle(
+                      fontSize: 15,
                     ),
-                  ],
-                ),
-                ),
-              ]
-            ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.all(10.0),
+                    child: TextButton(
+                      onPressed: null,
+                      style: ButtonStyle(
+                        backgroundColor: MaterialStateProperty.all<Color>(Colors.green),
+                        foregroundColor: MaterialStateProperty.all<Color>(Colors.white),
+                      ),
+                      child: const Text('Edit Profile'),
+                    ),
+                  ),
+                ],
+              ),
+              ),
+            ]
           ),
           const Divider(
             height: 7,
@@ -116,7 +121,7 @@ class _ProfilePageState extends State<ProfilePage> {
             color: Colors.black,
           ),
           Container(
-            padding: EdgeInsets.all(10.0),
+            padding: const EdgeInsets.all(10.0),
             child:
               Column(
                 crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -134,7 +139,7 @@ class _ProfilePageState extends State<ProfilePage> {
                       Padding(
                         padding: const EdgeInsets.all(10.0),
                         child: ListTile(
-                          title: Center(child: Text(interest, style: const TextStyle(fontWeight: FontWeight.bold)),),
+                          title: Center(child: Text(interest, style: const TextStyle(fontWeight: FontWeight.bold))),
                           textColor: Colors.white,
                           tileColor: Colors.lightBlue,
                         ),
@@ -202,7 +207,7 @@ class _ProfilePageState extends State<ProfilePage> {
                                   )
                               ),
                               Padding(
-                                  padding: EdgeInsets.only(left: 15.0, top: 2.0),
+                                  padding: const EdgeInsets.only(left: 15.0, top: 2.0),
                                   child: Align(
                                     alignment: Alignment.centerLeft,
                                     child: Text("${group.userIds.length} people"),
@@ -229,7 +234,6 @@ class _ProfilePageState extends State<ProfilePage> {
                     ),
                   ]
                 ),
-
               ],
             ),
           ), //Courses

--- a/lib/screens/friendslist.dart
+++ b/lib/screens/friendslist.dart
@@ -1,3 +1,4 @@
+import 'package:connectuni/components/user_card_widget.dart';
 import 'package:connectuni/model/userList.dart';
 import 'package:flutter/material.dart';
 
@@ -53,7 +54,7 @@ class _FriendsListState extends State<FriendsList> {
             ),
             ...usersDB
                 .getUsers()
-                .map((uName) => UserCardSearch(name: uName.displayName)),
+                .map((uName) => UserCardWidget(id: uName.uid)),
           ],
         ),
       ),

--- a/lib/screens/friendslist.dart
+++ b/lib/screens/friendslist.dart
@@ -52,7 +52,7 @@ class _FriendsListState extends State<FriendsList> {
             ),
             ...currentUser
                 .friends
-                .map((uName) => UserCardWidget(user: uName)),
+                .map((user) => UserCardWidget(user: user)),
           ],
         ),
       ),

--- a/lib/screens/friendslist.dart
+++ b/lib/screens/friendslist.dart
@@ -2,8 +2,6 @@ import 'package:connectuni/components/user_card_widget.dart';
 import 'package:connectuni/model/userList.dart';
 import 'package:flutter/material.dart';
 
-import '../components/user_card_search.dart';
-
 class FriendsList extends StatefulWidget {
   const FriendsList({Key? key}) : super(key: key);
 
@@ -52,9 +50,9 @@ class _FriendsListState extends State<FriendsList> {
                 });
               }),
             ),
-            ...usersDB
-                .getUsers()
-                .map((uName) => UserCardWidget(id: uName.uid)),
+            ...currentUser
+                .friends
+                .map((uName) => UserCardWidget(user: uName)),
           ],
         ),
       ),

--- a/lib/screens/other_user_profile.dart
+++ b/lib/screens/other_user_profile.dart
@@ -1,3 +1,4 @@
+import 'package:connectuni/model/group.dart';
 import 'package:flutter/material.dart';
 
 import '../model/user.dart';
@@ -35,7 +36,7 @@ class OtherUserProfile extends StatelessWidget {
          isFriend(thisUser) ?
               IconButton(
                   onPressed: () {
-                    // TODO Add functionality to remove friend
+                    currentUser.friends.remove(thisUser);
                   },
                   icon: const Icon(
                     Icons.person_remove,
@@ -44,7 +45,7 @@ class OtherUserProfile extends StatelessWidget {
               ) :
               IconButton(
                   onPressed: () {
-                    // TODO Add functionality to add friend
+                    currentUser.friends.remove(thisUser);
                   },
                   icon: const Icon(
                     Icons.person_add,
@@ -57,15 +58,18 @@ class OtherUserProfile extends StatelessWidget {
         padding: const EdgeInsets.all(20.0),
         children: [
           Column(
-            children: [
-              CircleAvatar(
-                radius: 50,
-                backgroundImage: AssetImage(thisUser.pfp),
-              )
-            ],
-          ),
-          Column(
               children: [
+                CircleAvatar(
+                  radius: 50,
+                  backgroundImage: AssetImage(thisUser.pfp),
+                ),
+                Text(
+                  thisUser.displayName,
+                  style: const TextStyle(
+                    fontSize: 23.0,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
                 Text(
                   'Major: ${thisUser.major}',
                   style: const TextStyle(
@@ -75,7 +79,141 @@ class OtherUserProfile extends StatelessWidget {
                 Text(
                   'Projected Grad: ${thisUser.projectedGraduation}',
                   style: const TextStyle(
-                    fontSize: 15,
+                    fontSize: 15.0,
+                  ),
+                ),
+                Text(
+                  'Status: ${thisUser.status}',
+                  style: const TextStyle(
+                    fontSize: 15.0,
+                  ),
+                ),
+                Text(
+                  'Friends: ${thisUser.friends.length}',
+                  style: const TextStyle(
+                    fontSize: 15.0,
+                  ),
+                ),
+                const Divider(
+                  height:7,
+                  thickness: 2,
+                  indent: 20,
+                  endIndent: 20,
+                  color: Colors.black,
+                ),
+                Container(
+                  padding: const EdgeInsets.all(10.0),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      const Text(
+                        "Their Interests",
+                        style: TextStyle(
+                          fontSize: 20,
+                          fontWeight: FontWeight.bold,
+                        ),
+                        textAlign: TextAlign.left,
+                      ),
+                      Column(
+                        children:[
+                          ...currentUser.interests.map((interest) => Padding(
+                            padding: const EdgeInsets.all(5.0),
+                            child: ListTile(
+                              title: Center(
+                                child: Text(
+                                  interest,
+                                  style: const TextStyle(
+                                    fontWeight: FontWeight.bold,
+                                  ),
+                                ),
+                              ),
+                              textColor: Colors.white,
+                              tileColor: Colors.lightBlue,
+                            ),
+                          )),
+                        ]
+                      ),
+                    ],
+                  )
+                ),
+                const Divider(
+                  height:7,
+                  thickness: 2,
+                  indent: 20,
+                  endIndent: 20,
+                  color: Colors.black,
+                ),
+                Container(
+                  padding: const EdgeInsets.only(top: 10, left: 5, right: 5),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      const Text(
+                        "Their Courses:",
+                        style: TextStyle(
+                          fontSize: 20,
+                          fontWeight: FontWeight.bold,
+                        ),
+                        textAlign: TextAlign.left,
+                      ),
+                      Column(
+                        children: [
+                          ...groupsDB
+                              .getGroupsByUser(thisUser.uid)
+                              .map((group) =>
+                              Card(
+                                elevation: 8,
+                                color: Colors.white,
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(15),
+                                  side: BorderSide(
+                                    color: Colors.grey.withOpacity(0.2),
+                                    width: 1,
+                                  ),
+                                ),
+                                child: Column(
+                                  children: [
+                                    ListTile(
+                                      title: Text(group.groupName,
+                                          style: const TextStyle(fontWeight: FontWeight.bold)),
+                                    ),
+                                    Padding(
+                                        padding: const EdgeInsets.only(left: 15.0, top: 5.0),
+                                        child: Align(
+                                          alignment: Alignment.centerLeft,
+                                          child: Text("${group.semYear} | ${group.professor}"),
+                                        )
+                                    ),
+                                    Padding(
+                                        padding: const EdgeInsets.only(left: 15.0, top: 2.0),
+                                        child: Align(
+                                          alignment: Alignment.centerLeft,
+                                          child: Text("${group.userIds.length} people"),
+                                        )
+                                    ),
+                                    Padding(
+                                        padding: const EdgeInsets.only(right: 15.0),
+                                        child: Align(
+                                          alignment: Alignment.bottomRight,
+                                          child: TextButton(
+                                            onPressed: () {group.addUserId(thisUser.uid);},
+                                            style: ButtonStyle(
+                                              backgroundColor: MaterialStateProperty.all<Color>(Colors.green),
+                                              foregroundColor: MaterialStateProperty.all<Color>(Colors.white),
+                                            ),
+                                            child: const Text('Join'),
+                                          ),
+                                        )
+                                    ),
+                                    const SizedBox(height: 10)
+                                  ],
+                                ),
+                              ),
+                          ),
+                        ],
+                      )
+                    ],
                   ),
                 ),
               ]

--- a/lib/screens/other_user_profile.dart
+++ b/lib/screens/other_user_profile.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+
+import '../model/user.dart';
+import '../model/userList.dart';
+
+class OtherUserProfile extends StatelessWidget {
+  const OtherUserProfile({Key? key, required this.uid}) : super(key: key);
+
+  final String uid;
+
+  bool isFriend(User user) {
+    if (currentUser.friends.contains(user)) {
+      return true;
+    }
+    return false;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    User thisUser = usersDB.getUserByID(uid);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(thisUser.displayName),
+        actions: [
+          IconButton(
+            icon: const Icon(
+              Icons.message,
+              semanticLabel: 'message',
+            ),
+            onPressed: () {
+              // TODO Add functionality to message user
+            },
+          ),
+         isFriend(thisUser) ?
+              IconButton(
+                  onPressed: () {
+                    // TODO Add functionality to remove friend
+                  },
+                  icon: const Icon(
+                    Icons.person_remove,
+                    semanticLabel: 'remove friend',
+                  ),
+              ) :
+              IconButton(
+                  onPressed: () {
+                    // TODO Add functionality to add friend
+                  },
+                  icon: const Icon(
+                    Icons.person_add,
+                    semanticLabel: 'add friend',
+                  )
+              )
+        ],
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(20.0),
+        children: [
+          Column(
+            children: [
+              CircleAvatar(
+                radius: 50,
+                backgroundImage: AssetImage(thisUser.pfp),
+              )
+            ],
+          ),
+          Column(
+              children: [
+                Text(
+                  'Major: ${thisUser.major}',
+                  style: const TextStyle(
+                    fontSize: 15.0,
+                  ),
+                ),
+                Text(
+                  'Projected Grad: ${thisUser.projectedGraduation}',
+                  style: const TextStyle(
+                    fontSize: 15,
+                  ),
+                ),
+              ]
+          ),
+        ],
+      )
+    );
+  }
+}

--- a/lib/screens/search_people_screen.dart
+++ b/lib/screens/search_people_screen.dart
@@ -1,5 +1,4 @@
 import 'package:connectuni/model/userList.dart';
-import 'package:connectuni/components/user_card_search.dart';
 import 'package:flutter/material.dart';
 import 'package:multi_select_flutter/multi_select_flutter.dart';
 

--- a/lib/screens/search_people_screen.dart
+++ b/lib/screens/search_people_screen.dart
@@ -3,6 +3,7 @@ import 'package:connectuni/components/user_card_search.dart';
 import 'package:flutter/material.dart';
 import 'package:multi_select_flutter/multi_select_flutter.dart';
 
+import '../components/user_card_widget.dart';
 import '../model/group.dart';
 
 class SearchPeopleScreen extends StatefulWidget {
@@ -20,6 +21,10 @@ class _SearchPeopleScreenState extends State<SearchPeopleScreen> {
   final _items = groupsDB
       .getAllGroups()
       .map((gName) => MultiSelectItem(gName, gName.groupName))
+      .toList();
+  final notFriends = usersDB
+      .getUsers()
+      .where((user) => !currentUser.friends.contains(user))
       .toList();
 
   @override
@@ -115,9 +120,7 @@ class _SearchPeopleScreenState extends State<SearchPeopleScreen> {
                 });
               }),
             ),
-            ...usersDB
-                .getUsers()
-                .map((uName) => UserCardSearch(name: uName.displayName)),
+            ...notFriends.map((user) => UserCardWidget(user: user)),
           ],
         ),
       ),

--- a/lib/screens/signup.dart
+++ b/lib/screens/signup.dart
@@ -1,5 +1,5 @@
 import 'package:connectuni/home/home.dart';
-import 'package:connectuni/screens/profile.dart';
+import 'package:connectuni/screens/current_user_profile.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 

--- a/lib/utils/global_variables.dart
+++ b/lib/utils/global_variables.dart
@@ -1,5 +1,5 @@
 import 'package:connectuni/screens/eventCalendar.dart';
-import 'package:connectuni/screens/profile.dart';
+import 'package:connectuni/screens/current_user_profile.dart';
 import 'package:flutter/material.dart';
 import 'package:connectuni/home/search_page_controller.dart';
 import 'package:connectuni/screens/groups_screen.dart';
@@ -9,7 +9,7 @@ List<Widget> screenItems = [
   const GroupsScreen(),
   const SearchPageController(),
   EventCalendar(),
-  ProfilePage()
+  const CurrentUserProfilePage()
 ];
 
 // This is a list of interests that can be called from anywhere in the app.


### PR DESCRIPTION
## Changes
- Renamed profile.dart to current_user_profile.dart, refactored all where exists in app.
- Added navigation to OtherUserProfile() on message button in UserCardSearch(). /// Should be changed later to navigate to dm them.
- Added new UserCardWidget() to make UserCardSearch() tap-able and navigatable to OtherUserProfile().
- Added a current user that can be called across the app called currentUser in users.dart
- Changed .restorablePushNamed() to MaterialPageRoute() in current_user_profile.dart
- Removed unnecessary container in current_user_profile.dart (dart fix)
- Changed friends list to display current user's friends:
`...usersDB
                .getUsers()
                .map((uName) => UserCardSearch(name: uName.displayName)),`
to
`...currentUser
                .friends
                .map((uName) => UserCardWidget(user: uName)),`
- Implemented OtherUserProfile()
- Changed SearchPeopleScreen() to display all users that are not on current user's friends list

## Examples of other user's profile page:
_(I still don't know why they are so big)_
![image](https://github.com/ConnectUni/connectuni/assets/89962623/0fa26094-63c7-4f4d-bff2-10c4a6e051e0)
![image](https://github.com/ConnectUni/connectuni/assets/89962623/659e1db1-a250-48af-bc21-7f69d9b87f13)
![image](https://github.com/ConnectUni/connectuni/assets/89962623/afca9c9a-2208-4aa0-a52b-e735d0c6c636)
