### PR TITLE
Implement the GroupDB provider rather than the TempGroupsDB Variable

### DIFF
--- a/lib/components/group_card_view.dart
+++ b/lib/components/group_card_view.dart
@@ -1,15 +1,17 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:connectuni/model/group.dart';
 import '../model/group_list.dart';
 
-class GroupCardView extends StatelessWidget {
+class GroupCardView extends ConsumerWidget {
   const GroupCardView({Key? key, required this.id}) : super(key: key);
 
   final String id;
 
   @override
-  Widget build(BuildContext context) {
-    Group thisGrouping = TempGroupsDB.getGroupById(id);
+  Widget build(BuildContext context, WidgetRef ref) {
+    final GroupList groupsDB = ref.watch(groupsDBProvider);
+    Group thisGrouping = groupsDB.getGroupById(id);
 
     return Padding(
       padding: const EdgeInsets.all(3.5),

--- a/lib/components/group_chat_widget.dart
+++ b/lib/components/group_chat_widget.dart
@@ -4,11 +4,12 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import '../model/group.dart';
 import '../model/group_list.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 /// GroupChatWidget is a widget that displays the group chat.
 /// It is a clickable widget that takes the user to the group chat page.
 
-class GroupChatWidget extends StatefulWidget {
+class GroupChatWidget extends ConsumerStatefulWidget {
   String id;
 
   GroupChatWidget({
@@ -17,13 +18,14 @@ class GroupChatWidget extends StatefulWidget {
   });
 
   @override
-  State<GroupChatWidget> createState() => _GroupChatWidgetState();
+  ConsumerState<GroupChatWidget> createState() => _GroupChatWidgetState();
 }
 
-class _GroupChatWidgetState extends State<GroupChatWidget> {
+class _GroupChatWidgetState extends ConsumerState<GroupChatWidget> {
   @override
   Widget build(BuildContext context) {
-    Group groupData = TempGroupsDB.getGroupById(widget.id);
+    final GroupList groupsDB = ref.watch(groupsDBProvider);
+    Group groupData = groupsDB.getGroupById(widget.id);
 
     return GestureDetector(
       onTap: () {

--- a/lib/components/groupselectorwidget.dart
+++ b/lib/components/groupselectorwidget.dart
@@ -1,51 +1,56 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../model/group.dart';
 import '../model/group_list.dart';
 import '../model/user.dart';
+import '../model/user_list.dart';
 
-class GroupSelector extends StatefulWidget {
+class GroupSelector extends ConsumerStatefulWidget {
   const GroupSelector({super.key});
 
   @override
-  State<GroupSelector> createState() => _GroupSelectorState();
+  ConsumerState<GroupSelector> createState() => _GroupSelectorState();
 }
 
-class _GroupSelectorState extends State<GroupSelector> {
-  final List<Group> _allGroups = TempGroupsDB.getAllGroups();
-  final List<Group> _selectedGroups = [];
-  late User currentUser;
+class _GroupSelectorState extends ConsumerState<GroupSelector> {
 
   @override
   Widget build(BuildContext context) {
+    final GroupList groupsDB = ref.watch(groupsDBProvider);
+    final List<Group> allGroups = groupsDB.getAllGroups();
+    final List<Group> selectedGroups = [];
+    final UserList userList = ref.watch(userDBProvider);
+    final User currentUser = userList.getUserByID(ref.watch(currentUserProvider));
+    void updateUserGroups() {
+      //i used a cast, not sure if this is the best way to implement
+      currentUser.groupIDs = selectedGroups.cast<String>();
+    }
     return Column(
       children: [
         Wrap(
           spacing: 6.0, // gap between adjacent chips
           runSpacing: 6.0, // gap between lines
-          children: _allGroups.map((group) => ChoiceChip(
+          children: allGroups.map((group) => ChoiceChip(
             label: Text(group.groupName),
-            selected: _selectedGroups.contains(group),
+            selected: selectedGroups.contains(group),
             onSelected: (selected) {
               setState(() {
                 if (selected) {
-                  _selectedGroups.add(group);
+                  selectedGroups.add(group);
                 } else {
-                  _selectedGroups.remove(group);
+                  selectedGroups.remove(group);
                 }
               });
             },
           )).toList(),
         ),
         ElevatedButton(
-          onPressed: _updateUserGroups,
+          onPressed: updateUserGroups,
           child: const Text("Update Groups"),
         )
       ],
     );
   }
 
-  void _updateUserGroups() {
-    //i used a cast, not sure if this is the best way to implement
-    currentUser.groupIDs = _selectedGroups.cast<String>();
-  }
+
 }

--- a/lib/model/group_list.dart
+++ b/lib/model/group_list.dart
@@ -180,4 +180,4 @@ final List<Group> allGroups = [
 ];
 
 //Provider that gives access to the total groups database.
-final groupsDBProvider = Provider<GroupList>((ref) { return GroupList(allGroups); });
+final groupsDBProvider = StateProvider<GroupList>((ref) { return GroupList(allGroups); });

--- a/lib/model/group_list.dart
+++ b/lib/model/group_list.dart
@@ -178,7 +178,6 @@ final List<Group> allGroups = [
     interests: ['Computer Science'],
   ),
 ];
-//TODO: Replace all instances of TempGroupsDB with the provider below
-GroupList TempGroupsDB = GroupList(allGroups);
 
+//Provider that gives access to the total groups database.
 final groupsDBProvider = Provider<GroupList>((ref) { return GroupList(allGroups); });

--- a/lib/screens/current_user_profile.dart
+++ b/lib/screens/current_user_profile.dart
@@ -29,6 +29,7 @@ class CurrentUserProfilePageState extends ConsumerState<CurrentUserProfilePage> 
   Widget build(BuildContext context) {
     final UserList userList = ref.watch(userDBProvider);
     final User currentUser = userList.getUserByID(ref.watch(currentUserProvider));
+    final GroupList groupDB = ref.watch(groupsDBProvider);
     return Scaffold(
         appBar: AppBar(
           title: const Text('My Profile'),
@@ -196,7 +197,7 @@ class CurrentUserProfilePageState extends ConsumerState<CurrentUserProfilePage> 
                         textAlign: TextAlign.left,
                       ),
                       Column(children: [
-                        ...TempGroupsDB.getGroupsByUser(currentUser.uid).map(
+                        ...groupDB.getGroupsByUser(currentUser.uid).map(
                               (group) => Card(
                                 elevation: 8,
                                 color: Colors.white,

--- a/lib/screens/eventCalendar.dart
+++ b/lib/screens/eventCalendar.dart
@@ -1,24 +1,20 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:table_calendar/table_calendar.dart';
-
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../model/event.dart';
 import '../model/event_list.dart';
 import 'package:multi_select_flutter/multi_select_flutter.dart';
 import '../model/group_list.dart';
 import 'event_info_screen.dart';
 
-class EventCalendar extends StatefulWidget {
+class EventCalendar extends ConsumerStatefulWidget {
   @override
   _EventCalendarState createState() => _EventCalendarState();
 }
 
-class _EventCalendarState extends State<EventCalendar> {
+class _EventCalendarState extends ConsumerState<EventCalendar> {
   late final ValueNotifier<List<SingleEvent>> _selectedEvents;
-  final _items = TempGroupsDB
-      .getAllGroups()
-      .map((gName) => MultiSelectItem(gName, gName.groupName))
-      .toList();
   CalendarFormat _calendarFormat = CalendarFormat.month;
   RangeSelectionMode _rangeSelectionMode = RangeSelectionMode
       .toggledOff; // Can be toggled on/off by longpressing a date
@@ -75,6 +71,11 @@ class _EventCalendarState extends State<EventCalendar> {
 
   @override
   Widget build(BuildContext context) {
+    final GroupList groupsDB = ref.watch(groupsDBProvider);
+    final _items = groupsDB
+        .getAllGroups()
+        .map((gName) => MultiSelectItem(gName, gName.groupName))
+        .toList();
     return Scaffold(
       appBar: AppBar(
         title: const Text('Events Calendar'),

--- a/lib/screens/group_chat_screen.dart
+++ b/lib/screens/group_chat_screen.dart
@@ -26,7 +26,9 @@ class _GroupChatScreenState extends ConsumerState<GroupChatScreen> {
   @override
   Widget build(BuildContext context) {
     final UserList usersDB = ref.read(userDBProvider);
-    Group groupData = TempGroupsDB.getGroupById(widget.id);
+    final GroupList groupsDB = ref.watch(groupsDBProvider);
+    Group groupData = groupsDB.getGroupById(widget.id);
+
     Iterable<User> groupMembers = usersDB.getGroupMembers(groupData.userIDs);
     Iterable<Message> messageData =
         TempMessagesDB.getGroupMessages(groupData.groupID);

--- a/lib/screens/groupinfo.dart
+++ b/lib/screens/groupinfo.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:connectuni/model/group.dart';
 import '../model/group_list.dart';
+import '../model/user_list.dart';
 
 /// Information page for a specific group that displays the group members as well as a description of the selected group.
 /// There is an icon at the upper right-hand corner for more statistic-related properties of the group.
@@ -23,6 +24,7 @@ class _GroupInfoState extends ConsumerState<GroupInfo> {
   @override
   Widget build(BuildContext context) {
     final GroupList groupsDB = ref.watch(groupsDBProvider);
+    final String currentUser = ref.watch(currentUserProvider);
     Group groupData = groupsDB.getGroupById(widget.id);
     return Scaffold(
       appBar: AppBar(
@@ -96,14 +98,15 @@ class _GroupInfoState extends ConsumerState<GroupInfo> {
             color: Colors.black,
           ),
           //Display a button to leave the group if the user is in the group.
-          if (groupData.userIDs.contains('user-001'))
+          if (groupData.userIDs.contains(currentUser))
             Padding(
               padding: const EdgeInsets.all(10.0),
               //TODO: Make this button conditional on whether or not the user is in the group.
               child: TextButton(
                 onPressed: () {
-                  //Placeholder currently only removes the first user:
-                  groupData.removeUserId('user-001');
+                  //Remove the user from the group's database. Then Refresh the group's database.
+                  groupData.removeUserId(currentUser);
+                  //TODO: Remove groupId from user.
                   ref.refresh(groupsDBProvider);
                 },
                 style: ButtonStyle(
@@ -115,14 +118,15 @@ class _GroupInfoState extends ConsumerState<GroupInfo> {
               ),
             ),
           //Display a button to join the group if the user is not in the group.
-          if (!groupData.userIDs.contains('user-001'))
+          if (!groupData.userIDs.contains(currentUser))
             Padding(
               padding: const EdgeInsets.all(10.0),
               //TODO: Make this button conditional on whether or not the user is in the group.
               child: TextButton(
                 onPressed: () {
-                  //Placeholder currently only removes the first user:
-                  groupData.addUserId('user-001');
+                  //Add the user from the group's database. Then Refresh the group's database.
+                  groupData.addUserId(currentUser);
+                  //TODO: Add groupId from user.
                   ref.refresh(groupsDBProvider);
                 },
                 style: ButtonStyle(

--- a/lib/screens/groupinfo.dart
+++ b/lib/screens/groupinfo.dart
@@ -1,6 +1,6 @@
 import 'package:connectuni/components/group_member_widget.dart';
 import 'package:flutter/material.dart';
-
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:connectuni/model/group.dart';
 import '../model/group_list.dart';
 
@@ -8,7 +8,7 @@ import '../model/group_list.dart';
 /// There is an icon at the upper right-hand corner for more statistic-related properties of the group.
 
 
-class GroupInfo extends StatefulWidget {
+class GroupInfo extends ConsumerStatefulWidget {
   final String id;
 
   const GroupInfo({
@@ -16,13 +16,14 @@ class GroupInfo extends StatefulWidget {
     required this.id,
   }) : super(key: key);
 
-  State<GroupInfo> createState() => _GroupInfoState();
+  ConsumerState<GroupInfo> createState() => _GroupInfoState();
 }
 
-class _GroupInfoState extends State<GroupInfo> {
+class _GroupInfoState extends ConsumerState<GroupInfo> {
   @override
   Widget build(BuildContext context) {
-    Group groupData = TempGroupsDB.getGroupById(widget.id);
+    final GroupList groupsDB = ref.watch(groupsDBProvider);
+    Group groupData = groupsDB.getGroupById(widget.id);
     return Scaffold(
       appBar: AppBar(
         leading: const BackButton(),

--- a/lib/screens/groupinfo.dart
+++ b/lib/screens/groupinfo.dart
@@ -104,6 +104,7 @@ class _GroupInfoState extends ConsumerState<GroupInfo> {
                 onPressed: () {
                   //Placeholder currently only removes the first user:
                   groupData.removeUserId('user-001');
+                  ref.refresh(groupsDBProvider);
                 },
                 style: ButtonStyle(
                   backgroundColor: MaterialStateProperty.all<Color>(Colors.red),
@@ -122,6 +123,7 @@ class _GroupInfoState extends ConsumerState<GroupInfo> {
                 onPressed: () {
                   //Placeholder currently only removes the first user:
                   groupData.addUserId('user-001');
+                  ref.refresh(groupsDBProvider);
                 },
                 style: ButtonStyle(
                   backgroundColor:

--- a/lib/screens/groups_screen.dart
+++ b/lib/screens/groups_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:connectuni/components/group_chat_widget.dart';
 import 'package:flutter/material.dart';
 import '../model/group_list.dart';
+import '../model/user_list.dart';
 import '/screens/chatpage.dart';
 
 class GroupsScreen extends ConsumerStatefulWidget {
@@ -15,6 +16,7 @@ class _GroupsScreenState extends ConsumerState<GroupsScreen> {
   @override
   Widget build(BuildContext context) {
     final GroupList groupsDB = ref.watch(groupsDBProvider);
+    final String userId = ref.watch(currentUserProvider);
     return Scaffold(
       appBar: AppBar(
         title: const Text('My Groups'),
@@ -45,7 +47,7 @@ class _GroupsScreenState extends ConsumerState<GroupsScreen> {
         children: [
           //TODO: Implement functionality and make cards interactive rather than simply visual.
           ...groupsDB
-              .getAllGroups()
+              .getGroupsByUser(userId)
               .map((gName) => GroupChatWidget(id: gName.groupID)),
           const Center(
             //TODO: Implement functionality and change from ICON to Button

--- a/lib/screens/groups_screen.dart
+++ b/lib/screens/groups_screen.dart
@@ -1,18 +1,20 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:connectuni/components/group_chat_widget.dart';
 import 'package:flutter/material.dart';
 import '../model/group_list.dart';
 import '/screens/chatpage.dart';
 
-class GroupsScreen extends StatefulWidget {
+class GroupsScreen extends ConsumerStatefulWidget {
   const GroupsScreen({Key? key}) : super(key: key);
 
   @override
-  State createState() => _GroupsScreenState();
+  ConsumerState createState() => _GroupsScreenState();
 }
 
-class _GroupsScreenState extends State<GroupsScreen> {
+class _GroupsScreenState extends ConsumerState<GroupsScreen> {
   @override
   Widget build(BuildContext context) {
+    final GroupList groupsDB = ref.watch(groupsDBProvider);
     return Scaffold(
       appBar: AppBar(
         title: const Text('My Groups'),
@@ -42,7 +44,7 @@ class _GroupsScreenState extends State<GroupsScreen> {
       body: ListView(
         children: [
           //TODO: Implement functionality and make cards interactive rather than simply visual.
-          ...TempGroupsDB
+          ...groupsDB
               .getAllGroups()
               .map((gName) => GroupChatWidget(id: gName.groupID)),
           const Center(

--- a/lib/screens/other_user_profile.dart
+++ b/lib/screens/other_user_profile.dart
@@ -23,6 +23,7 @@ class OtherUserProfile extends ConsumerWidget {
     final UserList usersDB = ref.read(userDBProvider);
     User thisUser = usersDB.getUserByID(uid);
     final User currentUser = usersDB.getUserByID(ref.read(currentUserProvider));
+    final GroupList groupsDB = ref.watch(groupsDBProvider);
     return Scaffold(
       appBar: AppBar(
         title: Text(user.displayName),
@@ -159,7 +160,7 @@ class OtherUserProfile extends ConsumerWidget {
                     ),
                       Column(
                         children: [
-                          ...TempGroupsDB
+                          ...groupsDB
                               .getGroupsByUser(user.uid)
                               .map((group) =>
                               Card(

--- a/lib/screens/search_groups_screen.dart
+++ b/lib/screens/search_groups_screen.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:multi_select_flutter/multi_select_flutter.dart';
-
 import '../components/group_card_view.dart';
 import '../model/group_list.dart';
 
-class SearchGroupsScreen extends StatefulWidget {
+class SearchGroupsScreen extends ConsumerStatefulWidget {
   const SearchGroupsScreen({Key? key, required this.pageController})
       : super(key: key);
 
@@ -12,17 +12,18 @@ class SearchGroupsScreen extends StatefulWidget {
   final PageController pageController;
 
   @override
-  State<SearchGroupsScreen> createState() => _SearchGroupsScreenState();
+  ConsumerState<SearchGroupsScreen> createState() => _SearchGroupsScreenState();
 }
 
-class _SearchGroupsScreenState extends State<SearchGroupsScreen> {
-  final _items = TempGroupsDB
-      .getAllGroups()
-      .map((gName) => MultiSelectItem(gName, gName.groupName))
-      .toList();
+class _SearchGroupsScreenState extends ConsumerState<SearchGroupsScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final GroupList groupsDB = ref.watch(groupsDBProvider);
+    final _items = groupsDB
+        .getAllGroups()
+        .map((gName) => MultiSelectItem(gName, gName.groupName))
+        .toList();
     return Scaffold(
       appBar: AppBar(
         title: const Text('Search for Groups'),
@@ -118,14 +119,14 @@ class _SearchGroupsScreenState extends State<SearchGroupsScreen> {
               'RelatedCourses/Groups',
               textAlign: TextAlign.left,
             ),
-            ...TempGroupsDB
+            ...groupsDB
                 .getAllGroups()
                 .map((gName) => GroupCardView(id: gName.groupID)),
             const Text(
               'Other Groups',
               textAlign: TextAlign.left,
             ),
-            ...TempGroupsDB
+            ...groupsDB
                 .getAllGroups()
                 .map((gName) => GroupCardView(id: gName.groupID)),
             const Text('Events'),

--- a/lib/screens/search_people_screen.dart
+++ b/lib/screens/search_people_screen.dart
@@ -24,7 +24,8 @@ class _SearchPeopleScreenState extends ConsumerState<SearchPeopleScreen> {
   Widget build(BuildContext context) {
     final UserList usersDB = ref.read(userDBProvider);
     final User currentUser = usersDB.getUserByID(ref.read(currentUserProvider));
-    final _items = TempGroupsDB
+    final GroupList groupsDB = ref.watch(groupsDBProvider);
+    final _items = groupsDB
         .getAllGroups()
         .map((gName) => MultiSelectItem(gName, gName.groupName))
         .toList();


### PR DESCRIPTION
- Implemented the GroupsDB provider in all old TestGroupsDB instances.
- Added riverpod-based functionality to the GroupInfo Page.

NOTE: New ticket to fix the group chats page to accommodate for a group member leaving the group. (Currently breaks if the current user is not a part of the group).