### PR TITLE
Created AddGroup, Edit Group, and added more Riverpod-Based Group interactivity.

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -9,7 +9,7 @@ import 'package:flutter/material.dart';
 import 'screens/login.dart';
 import 'home/home.dart';
 import 'screens/chatpage.dart';
-import 'screens/groupinfo.dart';
+import 'screens/groups_screen/groupinfo.dart';
 import 'screens/settings.dart';
 import 'screens/current_user_profile.dart';
 import 'screens/search_people_screen.dart';

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -13,7 +13,7 @@ import 'screens/groupinfo.dart';
 import 'screens/settings.dart';
 import 'screens/current_user_profile.dart';
 import 'screens/search_people_screen.dart';
-import 'screens/search_groups_screen.dart';
+import 'screens/groups_screen/search_groups_screen.dart';
 
 // TODO: Import route files
 

--- a/lib/components/group_card_view.dart
+++ b/lib/components/group_card_view.dart
@@ -1,15 +1,17 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:connectuni/model/group.dart';
 import '../model/group_list.dart';
 
-class GroupCardView extends StatelessWidget {
+class GroupCardView extends ConsumerWidget {
   const GroupCardView({Key? key, required this.id}) : super(key: key);
 
   final String id;
 
   @override
-  Widget build(BuildContext context) {
-    Group thisGrouping = TempGroupsDB.getGroupById(id);
+  Widget build(BuildContext context, WidgetRef ref) {
+    final GroupList groupsDB = ref.watch(groupsDBProvider);
+    Group thisGrouping = groupsDB.getGroupById(id);
 
     return Padding(
       padding: const EdgeInsets.all(3.5),

--- a/lib/components/group_chat_widget.dart
+++ b/lib/components/group_chat_widget.dart
@@ -4,11 +4,12 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import '../model/group.dart';
 import '../model/group_list.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 /// GroupChatWidget is a widget that displays the group chat.
 /// It is a clickable widget that takes the user to the group chat page.
 
-class GroupChatWidget extends StatefulWidget {
+class GroupChatWidget extends ConsumerStatefulWidget {
   String id;
 
   GroupChatWidget({
@@ -17,13 +18,14 @@ class GroupChatWidget extends StatefulWidget {
   });
 
   @override
-  State<GroupChatWidget> createState() => _GroupChatWidgetState();
+  ConsumerState<GroupChatWidget> createState() => _GroupChatWidgetState();
 }
 
-class _GroupChatWidgetState extends State<GroupChatWidget> {
+class _GroupChatWidgetState extends ConsumerState<GroupChatWidget> {
   @override
   Widget build(BuildContext context) {
-    Group groupData = TempGroupsDB.getGroupById(widget.id);
+    final GroupList groupsDB = ref.watch(groupsDBProvider);
+    Group groupData = groupsDB.getGroupById(widget.id);
 
     return GestureDetector(
       onTap: () {

--- a/lib/components/group_info_widget.dart
+++ b/lib/components/group_info_widget.dart
@@ -1,5 +1,5 @@
 import 'package:connectuni/components/group_card_view.dart';
-import 'package:connectuni/screens/groupinfo.dart';
+import 'package:connectuni/screens/groups_screen/groupinfo.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import '../model/group.dart';

--- a/lib/components/group_info_widget.dart
+++ b/lib/components/group_info_widget.dart
@@ -1,0 +1,41 @@
+import 'package:connectuni/components/group_card_view.dart';
+import 'package:connectuni/screens/groupinfo.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import '../model/group.dart';
+import '../model/group_list.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// GroupChatWidget is a widget that displays the group chat.
+/// It is a clickable widget that takes the user to the group chat page.
+
+class GroupInfoWidget extends ConsumerStatefulWidget {
+  String id;
+
+  GroupInfoWidget({
+    super.key,
+    required this.id,
+  });
+
+  @override
+  ConsumerState<GroupInfoWidget> createState() => _GroupInfoWidgetState();
+}
+
+class _GroupInfoWidgetState extends ConsumerState<GroupInfoWidget> {
+  @override
+  Widget build(BuildContext context) {
+    final GroupList groupsDB = ref.watch(groupsDBProvider);
+    Group groupData = groupsDB.getGroupById(widget.id);
+
+    return GestureDetector(
+      onTap: () {
+        Navigator.push(
+          context,
+          CupertinoPageRoute(
+              builder: (context) => GroupInfo(id: groupData.groupID)),
+        );
+      },
+      child: GroupCardView(id: groupData.groupID),
+    );
+  }
+}

--- a/lib/components/groupselectorwidget.dart
+++ b/lib/components/groupselectorwidget.dart
@@ -1,51 +1,56 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../model/group.dart';
 import '../model/group_list.dart';
 import '../model/user.dart';
+import '../model/user_list.dart';
 
-class GroupSelector extends StatefulWidget {
+class GroupSelector extends ConsumerStatefulWidget {
   const GroupSelector({super.key});
 
   @override
-  State<GroupSelector> createState() => _GroupSelectorState();
+  ConsumerState<GroupSelector> createState() => _GroupSelectorState();
 }
 
-class _GroupSelectorState extends State<GroupSelector> {
-  final List<Group> _allGroups = TempGroupsDB.getAllGroups();
-  final List<Group> _selectedGroups = [];
-  late User currentUser;
+class _GroupSelectorState extends ConsumerState<GroupSelector> {
 
   @override
   Widget build(BuildContext context) {
+    final GroupList groupsDB = ref.watch(groupsDBProvider);
+    final List<Group> allGroups = groupsDB.getAllGroups();
+    final List<Group> selectedGroups = [];
+    final UserList userList = ref.watch(userDBProvider);
+    final User currentUser = userList.getUserByID(ref.watch(currentUserProvider));
+    void updateUserGroups() {
+      //i used a cast, not sure if this is the best way to implement
+      currentUser.groupIDs = selectedGroups.cast<String>();
+    }
     return Column(
       children: [
         Wrap(
           spacing: 6.0, // gap between adjacent chips
           runSpacing: 6.0, // gap between lines
-          children: _allGroups.map((group) => ChoiceChip(
+          children: allGroups.map((group) => ChoiceChip(
             label: Text(group.groupName),
-            selected: _selectedGroups.contains(group),
+            selected: selectedGroups.contains(group),
             onSelected: (selected) {
               setState(() {
                 if (selected) {
-                  _selectedGroups.add(group);
+                  selectedGroups.add(group);
                 } else {
-                  _selectedGroups.remove(group);
+                  selectedGroups.remove(group);
                 }
               });
             },
           )).toList(),
         ),
         ElevatedButton(
-          onPressed: _updateUserGroups,
+          onPressed: updateUserGroups,
           child: const Text("Update Groups"),
         )
       ],
     );
   }
 
-  void _updateUserGroups() {
-    //i used a cast, not sure if this is the best way to implement
-    currentUser.groupIDs = _selectedGroups.cast<String>();
-  }
+
 }

--- a/lib/home/search_page_controller.dart
+++ b/lib/home/search_page_controller.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-import '../screens/search_groups_screen.dart';
+import '../screens/groups_screen/search_groups_screen.dart';
 import '../screens/search_people_screen.dart';
 import '../screens/search_events_screen.dart';
 

--- a/lib/model/chat_list.dart
+++ b/lib/model/chat_list.dart
@@ -38,7 +38,5 @@ final List<Chat> mockChats = [
       userIDs: ['user-003', 'user-004', 'user-005'],
       messageIDs: ['message-013', 'message-014', 'message-015'])
 ];
-//TODO: replace all instances of this chatlist with the provider below:
-ChatList TempChatDB = ChatList(mockChats);
 
 final chatDBProvider = Provider<ChatList>((ref) { return ChatList(mockChats); });

--- a/lib/model/group_list.dart
+++ b/lib/model/group_list.dart
@@ -52,6 +52,36 @@ class GroupList {
     allGroups.add(group);
   }
 
+  void updateGroup({
+    required String groupID,
+    required String groupName,
+    required String semYear,
+    required String owner,
+    required String groupImage,
+    required String groupDescription,
+    required List<Message> newMessages,
+    required String chatID,
+    required List<String> eventIDs,
+    required List<String> userIDs,
+    required List<String> interests,
+  }) {
+    allGroups.removeWhere((group) => group.groupID == groupID);
+    allGroups.add(
+      Group(
+        groupID: groupID,
+        groupName: groupName,
+        semYear: semYear,
+        owner: owner,
+        groupImage: groupImage,
+        groupDescription: groupDescription,
+        newMessages: newMessages,
+        chatID: chatID,
+        eventIDs: eventIDs,
+        userIDs: userIDs,
+        interests: interests,
+      )
+    );
+  }
   /// Remove a group
   void removeGroup(Group group) {
     if (allGroups.contains(group)) {

--- a/lib/model/group_list.dart
+++ b/lib/model/group_list.dart
@@ -180,4 +180,4 @@ final List<Group> allGroups = [
 ];
 
 //Provider that gives access to the total groups database.
-final groupsDBProvider = Provider<GroupList>((ref) { return GroupList(allGroups); });
+final groupsDBProvider = StateProvider<GroupList>((ref) { return GroupList(allGroups); });

--- a/lib/model/group_list.dart
+++ b/lib/model/group_list.dart
@@ -178,7 +178,6 @@ final List<Group> allGroups = [
     interests: ['Computer Science'],
   ),
 ];
-//TODO: Replace all instances of TempGroupsDB with the provider below
-GroupList TempGroupsDB = GroupList(allGroups);
 
+//Provider that gives access to the total groups database.
 final groupsDBProvider = Provider<GroupList>((ref) { return GroupList(allGroups); });

--- a/lib/model/group_list.dart
+++ b/lib/model/group_list.dart
@@ -17,6 +17,11 @@ class GroupList {
     return allGroups;
   }
 
+  /// Return number of Group Objects
+  int groupLength() {
+    return allGroups.length;
+  }
+
   /// Return single Group object, search with their group ID
   Group getGroupById(String groupId) {
     return allGroups.firstWhere((group) => group.groupID == groupId);
@@ -181,3 +186,5 @@ final List<Group> allGroups = [
 
 //Provider that gives access to the total groups database.
 final groupsDBProvider = StateProvider<GroupList>((ref) { return GroupList(allGroups); });
+
+final groupsIDProvider = StateProvider<int>((ref) { return GroupList(allGroups).groupLength(); });

--- a/lib/screens/current_user_profile.dart
+++ b/lib/screens/current_user_profile.dart
@@ -29,6 +29,7 @@ class CurrentUserProfilePageState extends ConsumerState<CurrentUserProfilePage> 
   Widget build(BuildContext context) {
     final UserList userList = ref.watch(userDBProvider);
     final User currentUser = userList.getUserByID(ref.watch(currentUserProvider));
+    final GroupList groupDB = ref.watch(groupsDBProvider);
     return Scaffold(
         appBar: AppBar(
           title: const Text('My Profile'),
@@ -196,7 +197,7 @@ class CurrentUserProfilePageState extends ConsumerState<CurrentUserProfilePage> 
                         textAlign: TextAlign.left,
                       ),
                       Column(children: [
-                        ...TempGroupsDB.getGroupsByUser(currentUser.uid).map(
+                        ...groupDB.getGroupsByUser(currentUser.uid).map(
                               (group) => Card(
                                 elevation: 8,
                                 color: Colors.white,

--- a/lib/screens/current_user_profile.dart
+++ b/lib/screens/current_user_profile.dart
@@ -1,6 +1,7 @@
 import 'package:connectuni/model/user.dart';
 import 'package:flutter/material.dart';
 import 'package:connectuni/model/user_list.dart';
+import '../model/group.dart';
 import '../model/group_list.dart';
 import 'friend_list.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -238,8 +239,10 @@ class CurrentUserProfilePageState extends ConsumerState<CurrentUserProfilePage> 
                                           alignment: Alignment.bottomRight,
                                           child: TextButton(
                                             onPressed: () {
-                                              group.removeUserId(
-                                                  currentUser.uid);
+                                            //Remove the user from the group's database. Then Refresh the group's database.
+                                            group.removeUserId(currentUser.uid);
+                                             //TODO: Remove groupId from user.
+                                            ref.refresh(groupsDBProvider);
                                             },
                                             style: ButtonStyle(
                                               backgroundColor:

--- a/lib/screens/eventCalendar.dart
+++ b/lib/screens/eventCalendar.dart
@@ -1,24 +1,20 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:table_calendar/table_calendar.dart';
-
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../model/event.dart';
 import '../model/event_list.dart';
 import 'package:multi_select_flutter/multi_select_flutter.dart';
 import '../model/group_list.dart';
 import 'event_info_screen.dart';
 
-class EventCalendar extends StatefulWidget {
+class EventCalendar extends ConsumerStatefulWidget {
   @override
   _EventCalendarState createState() => _EventCalendarState();
 }
 
-class _EventCalendarState extends State<EventCalendar> {
+class _EventCalendarState extends ConsumerState<EventCalendar> {
   late final ValueNotifier<List<SingleEvent>> _selectedEvents;
-  final _items = TempGroupsDB
-      .getAllGroups()
-      .map((gName) => MultiSelectItem(gName, gName.groupName))
-      .toList();
   CalendarFormat _calendarFormat = CalendarFormat.month;
   RangeSelectionMode _rangeSelectionMode = RangeSelectionMode
       .toggledOff; // Can be toggled on/off by longpressing a date
@@ -75,6 +71,11 @@ class _EventCalendarState extends State<EventCalendar> {
 
   @override
   Widget build(BuildContext context) {
+    final GroupList groupsDB = ref.watch(groupsDBProvider);
+    final _items = groupsDB
+        .getAllGroups()
+        .map((gName) => MultiSelectItem(gName, gName.groupName))
+        .toList();
     return Scaffold(
       appBar: AppBar(
         title: const Text('Events Calendar'),

--- a/lib/screens/group_chat_screen.dart
+++ b/lib/screens/group_chat_screen.dart
@@ -26,7 +26,9 @@ class _GroupChatScreenState extends ConsumerState<GroupChatScreen> {
   @override
   Widget build(BuildContext context) {
     final UserList usersDB = ref.read(userDBProvider);
-    Group groupData = TempGroupsDB.getGroupById(widget.id);
+    final GroupList groupsDB = ref.watch(groupsDBProvider);
+    Group groupData = groupsDB.getGroupById(widget.id);
+
     Iterable<User> groupMembers = usersDB.getGroupMembers(groupData.userIDs);
     Iterable<Message> messageData =
         TempMessagesDB.getGroupMessages(groupData.groupID);

--- a/lib/screens/group_chat_screen.dart
+++ b/lib/screens/group_chat_screen.dart
@@ -8,7 +8,7 @@ import '../model/message.dart';
 import '../model/message_list.dart';
 import '../model/user.dart';
 import '../model/user_list.dart';
-import 'groupinfo.dart';
+import 'groups_screen/groupinfo.dart';
 
 class GroupChatScreen extends ConsumerStatefulWidget {
   final String id;

--- a/lib/screens/groupinfo.dart
+++ b/lib/screens/groupinfo.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:connectuni/model/group.dart';
 import '../model/group_list.dart';
+import '../model/user_list.dart';
 
 /// Information page for a specific group that displays the group members as well as a description of the selected group.
 /// There is an icon at the upper right-hand corner for more statistic-related properties of the group.
@@ -23,6 +24,7 @@ class _GroupInfoState extends ConsumerState<GroupInfo> {
   @override
   Widget build(BuildContext context) {
     final GroupList groupsDB = ref.watch(groupsDBProvider);
+    final String currentUser = ref.watch(currentUserProvider);
     Group groupData = groupsDB.getGroupById(widget.id);
     return Scaffold(
       appBar: AppBar(
@@ -96,14 +98,15 @@ class _GroupInfoState extends ConsumerState<GroupInfo> {
             color: Colors.black,
           ),
           //Display a button to leave the group if the user is in the group.
-          if (groupData.userIDs.contains('user-001'))
+          if (groupData.userIDs.contains(currentUser))
             Padding(
               padding: const EdgeInsets.all(10.0),
               //TODO: Make this button conditional on whether or not the user is in the group.
               child: TextButton(
                 onPressed: () {
-                  //Placeholder currently only removes the first user:
-                  groupData.removeUserId('user-001');
+                  //Remove the user from the group's database. Then Refresh the group's database.
+                  groupData.removeUserId(currentUser);
+                  //TODO: Remove groupId from user.
                   ref.refresh(groupsDBProvider);
                 },
                 style: ButtonStyle(
@@ -115,14 +118,15 @@ class _GroupInfoState extends ConsumerState<GroupInfo> {
               ),
             ),
           //Display a button to join the group if the user is not in the group.
-          if (!groupData.userIDs.contains('user-001'))
+          if (!groupData.userIDs.contains(currentUser))
             Padding(
               padding: const EdgeInsets.all(10.0),
               //TODO: Make this button conditional on whether or not the user is in the group.
               child: TextButton(
                 onPressed: () {
-                  //Placeholder currently only removes the first user:
-                  groupData.addUserId('user-001');
+                  //Add the user from the group's database. Then Refresh the group's database.
+                  groupData.addUserId(currentUser);
+                  //TODO: Add groupId from user.
                   ref.refresh(groupsDBProvider);
                 },
                 style: ButtonStyle(

--- a/lib/screens/groupinfo.dart
+++ b/lib/screens/groupinfo.dart
@@ -1,6 +1,6 @@
 import 'package:connectuni/components/group_member_widget.dart';
 import 'package:flutter/material.dart';
-
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:connectuni/model/group.dart';
 import '../model/group_list.dart';
 
@@ -8,7 +8,7 @@ import '../model/group_list.dart';
 /// There is an icon at the upper right-hand corner for more statistic-related properties of the group.
 
 
-class GroupInfo extends StatefulWidget {
+class GroupInfo extends ConsumerStatefulWidget {
   final String id;
 
   const GroupInfo({
@@ -16,13 +16,14 @@ class GroupInfo extends StatefulWidget {
     required this.id,
   }) : super(key: key);
 
-  State<GroupInfo> createState() => _GroupInfoState();
+  ConsumerState<GroupInfo> createState() => _GroupInfoState();
 }
 
-class _GroupInfoState extends State<GroupInfo> {
+class _GroupInfoState extends ConsumerState<GroupInfo> {
   @override
   Widget build(BuildContext context) {
-    Group groupData = TempGroupsDB.getGroupById(widget.id);
+    final GroupList groupsDB = ref.watch(groupsDBProvider);
+    Group groupData = groupsDB.getGroupById(widget.id);
     return Scaffold(
       appBar: AppBar(
         leading: const BackButton(),

--- a/lib/screens/groupinfo.dart
+++ b/lib/screens/groupinfo.dart
@@ -104,6 +104,7 @@ class _GroupInfoState extends ConsumerState<GroupInfo> {
                 onPressed: () {
                   //Placeholder currently only removes the first user:
                   groupData.removeUserId('user-001');
+                  ref.refresh(groupsDBProvider);
                 },
                 style: ButtonStyle(
                   backgroundColor: MaterialStateProperty.all<Color>(Colors.red),
@@ -122,6 +123,7 @@ class _GroupInfoState extends ConsumerState<GroupInfo> {
                 onPressed: () {
                   //Placeholder currently only removes the first user:
                   groupData.addUserId('user-001');
+                  ref.refresh(groupsDBProvider);
                 },
                 style: ButtonStyle(
                   backgroundColor:

--- a/lib/screens/groups_screen.dart
+++ b/lib/screens/groups_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:connectuni/components/group_chat_widget.dart';
 import 'package:flutter/material.dart';
 import '../model/group_list.dart';
+import '../model/user_list.dart';
 import '/screens/chatpage.dart';
 
 class GroupsScreen extends ConsumerStatefulWidget {
@@ -15,6 +16,7 @@ class _GroupsScreenState extends ConsumerState<GroupsScreen> {
   @override
   Widget build(BuildContext context) {
     final GroupList groupsDB = ref.watch(groupsDBProvider);
+    final String userId = ref.watch(currentUserProvider);
     return Scaffold(
       appBar: AppBar(
         title: const Text('My Groups'),
@@ -45,7 +47,7 @@ class _GroupsScreenState extends ConsumerState<GroupsScreen> {
         children: [
           //TODO: Implement functionality and make cards interactive rather than simply visual.
           ...groupsDB
-              .getAllGroups()
+              .getGroupsByUser(userId)
               .map((gName) => GroupChatWidget(id: gName.groupID)),
           const Center(
             //TODO: Implement functionality and change from ICON to Button

--- a/lib/screens/groups_screen.dart
+++ b/lib/screens/groups_screen.dart
@@ -50,12 +50,18 @@ class _GroupsScreenState extends ConsumerState<GroupsScreen> {
               .getGroupsByUser(userId)
               .map((gName) => GroupChatWidget(id: gName.groupID)),
           const Center(
-            //TODO: Implement functionality and change from ICON to Button
-            child: Icon(
-              Icons.add_circle_outline,
-              color: Colors.grey,
-              size: 40.0,
-            ),
+            child:
+            Padding(
+              padding: EdgeInsets.only(bottom: 10.0),
+              child: IconButton(
+                onPressed: null,
+                icon: Icon(
+                  Icons.add_circle_outline,
+                  color: Colors.grey,
+                  size: 40.0,
+                ),
+              ),
+            )
           ),
         ],
       ),

--- a/lib/screens/groups_screen.dart
+++ b/lib/screens/groups_screen.dart
@@ -1,18 +1,20 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:connectuni/components/group_chat_widget.dart';
 import 'package:flutter/material.dart';
 import '../model/group_list.dart';
 import '/screens/chatpage.dart';
 
-class GroupsScreen extends StatefulWidget {
+class GroupsScreen extends ConsumerStatefulWidget {
   const GroupsScreen({Key? key}) : super(key: key);
 
   @override
-  State createState() => _GroupsScreenState();
+  ConsumerState createState() => _GroupsScreenState();
 }
 
-class _GroupsScreenState extends State<GroupsScreen> {
+class _GroupsScreenState extends ConsumerState<GroupsScreen> {
   @override
   Widget build(BuildContext context) {
+    final GroupList groupsDB = ref.watch(groupsDBProvider);
     return Scaffold(
       appBar: AppBar(
         title: const Text('My Groups'),
@@ -42,7 +44,7 @@ class _GroupsScreenState extends State<GroupsScreen> {
       body: ListView(
         children: [
           //TODO: Implement functionality and make cards interactive rather than simply visual.
-          ...TempGroupsDB
+          ...groupsDB
               .getAllGroups()
               .map((gName) => GroupChatWidget(id: gName.groupID)),
           const Center(

--- a/lib/screens/groups_screen/add_group.dart
+++ b/lib/screens/groups_screen/add_group.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_form_builder/flutter_form_builder.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../model/group.dart';
+import '../../model/group_list.dart';
+import '../../model/message.dart';
+import 'form-fields/group_description_field.dart';
+import 'form-fields/group_image_field.dart';
+import 'form-fields/group_name_field.dart';
+import 'form-fields/owner_field.dart';
+import 'form-fields/reset_button.dart';
+import 'form-fields/semyear_field.dart';
+import 'form-fields/submit_button.dart';
+
+//Creates a new Group
+class AddGroup extends ConsumerWidget {
+  AddGroup({Key? key}) : super(key: key);
+  final _formKey = GlobalKey<FormBuilderState>();
+  final _groupNameFieldKey = GlobalKey<FormBuilderFieldState>();
+  final _semYearFieldKey = GlobalKey<FormBuilderFieldState>();
+  final _ownerFieldKey = GlobalKey<FormBuilderFieldState>();
+  final _groupImageFieldKey = GlobalKey<FormBuilderFieldState>();
+  final _groupDescriptionFieldKey = GlobalKey<FormBuilderFieldState>();
+
+  final List<Message> newMessages = [];
+  final List<String> eventIDs = [];
+  final List<String> userIDs = [];
+  final List<String> interests = [];
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final GroupList groupsDB = ref.watch(groupsDBProvider);
+    int id = groupsDB.groupLength() + 1;
+    String getGroupID() {
+      if (id < 10) {
+        return "group-00$id";
+      } else if (id < 100) {
+        return "group-0$id";
+      } else {
+        return "group-$id";
+      }
+    }
+    String getChatID() {
+      if (id < 10) {
+        return "chat-00$id";
+      } else if (id < 100) {
+        return "chat-0$id";
+      } else {
+        return "chat-$id";
+      }
+    }
+
+    void onSubmit() {
+      bool isValid = _formKey.currentState?.saveAndValidate() ?? false;
+      if (!isValid) return;
+      String groupID = getGroupID();
+      String groupName = _groupNameFieldKey.currentState?.value;
+      String semYear = _semYearFieldKey.currentState?.value;
+      String owner = _ownerFieldKey.currentState?.value;
+      String groupImage = _groupImageFieldKey.currentState?.value;
+      String groupDescription = _groupDescriptionFieldKey.currentState?.value;
+      String chatID = getChatID();
+      groupsDB.addGroup(
+        Group(
+        groupID: groupID,
+        groupName: groupName,
+        semYear: semYear,
+        owner: owner,
+        groupImage: groupImage,
+        groupDescription: groupDescription,
+        newMessages: newMessages,
+        chatID: chatID,
+        eventIDs: eventIDs,
+        userIDs: userIDs,
+        interests: interests,
+        )
+      );
+      //Return to the previous page
+      ref.refresh(groupsDBProvider);
+      Navigator.pop(context);
+
+    }
+
+    void onReset() {
+      _formKey.currentState?.reset();
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Add Group'),
+      ),
+      body: ListView(
+        padding: const EdgeInsets.symmetric(horizontal: 24.0),
+        children: [
+          Column(
+            children: [
+              FormBuilder(
+                key: _formKey,
+                child: Column(
+                  children: [
+                    GroupNameField(fieldKey: _groupNameFieldKey),
+                    SemYearField(fieldKey: _semYearFieldKey),
+                    OwnerField(fieldKey: _ownerFieldKey),
+                    GroupImageField(fieldKey: _groupImageFieldKey),
+                    GroupDescriptionField(fieldKey: _groupDescriptionFieldKey),
+                  ]
+                ),
+              ),
+              Row(
+                children: [
+                  SubmitButton(onSubmit: onSubmit),
+                  ResetButton(onReset: onReset),
+                ]
+              )
+            ],
+          ),
+        ],
+      )
+    );
+  }
+}

--- a/lib/screens/groups_screen/add_group.dart
+++ b/lib/screens/groups_screen/add_group.dart
@@ -58,8 +58,8 @@ class AddGroup extends ConsumerWidget {
       String groupName = _groupNameFieldKey.currentState?.value;
       String semYear = _semYearFieldKey.currentState?.value;
       String owner = _ownerFieldKey.currentState?.value;
-      String groupImage = _groupImageFieldKey.currentState?.value;
-      String groupDescription = _groupDescriptionFieldKey.currentState?.value;
+      String groupImage = _groupImageFieldKey.currentState?.value ?? '';
+      String groupDescription = _groupDescriptionFieldKey.currentState?.value ?? '';
       String chatID = getChatID();
       groupsDB.addGroup(
         Group(

--- a/lib/screens/groups_screen/edit_group.dart
+++ b/lib/screens/groups_screen/edit_group.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_form_builder/flutter_form_builder.dart';
+
+import '../../model/group.dart';
+import '../../model/group_list.dart';
+import 'form-fields/group_description_field.dart';
+import 'form-fields/group_image_field.dart';
+import 'form-fields/group_name_field.dart';
+import 'form-fields/owner_field.dart';
+import 'form-fields/reset_button.dart';
+import 'form-fields/semyear_field.dart';
+import 'form-fields/submit_button.dart';
+
+class EditGroup extends ConsumerWidget {
+  final String id;
+  EditGroup({Key? key, required this.id}) : super(key: key);
+
+  final _formKey = GlobalKey<FormBuilderState>();
+  final _groupNameFieldKey = GlobalKey<FormBuilderFieldState>();
+  final _semYearFieldKey = GlobalKey<FormBuilderFieldState>();
+  final _ownerFieldKey = GlobalKey<FormBuilderFieldState>();
+  final _groupImageFieldKey = GlobalKey<FormBuilderFieldState>();
+  final _groupDescriptionFieldKey = GlobalKey<FormBuilderFieldState>();
+
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final GroupList groupsDB = ref.watch(groupsDBProvider);
+    Group editGroup = groupsDB.getGroupById(id);
+
+    void onSubmit() {
+      bool isValid = _formKey.currentState?.saveAndValidate() ?? false;
+      if (!isValid) return;
+      String groupID = id;
+      String groupName = _groupNameFieldKey.currentState?.value;
+      String semYear = _semYearFieldKey.currentState?.value;
+      String owner = _ownerFieldKey.currentState?.value;
+      String groupImage = _groupImageFieldKey.currentState?.value ?? '';
+      String groupDescription = _groupDescriptionFieldKey.currentState?.value ?? '';
+      groupsDB.updateGroup(
+            groupID: groupID,
+            groupName: groupName,
+            semYear: semYear,
+            owner: owner,
+            groupImage: groupImage,
+            groupDescription: groupDescription,
+            newMessages: editGroup.newMessages,
+            chatID: editGroup.chatID,
+            eventIDs: editGroup.eventIDs,
+            userIDs: editGroup.userIDs,
+            interests: editGroup.interests,
+      );
+      //Return to the previous page
+      ref.refresh(groupsDBProvider);
+      Navigator.pop(context);
+    }
+
+    void onReset() {
+      _formKey.currentState?.reset();
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Edit Group'),
+      ),
+        body: ListView(
+          padding: const EdgeInsets.symmetric(horizontal: 24.0),
+          children: [
+            Column(
+              children: [
+                FormBuilder(
+                  key: _formKey,
+                  child: Column(
+                      children: [
+                        GroupNameField(fieldKey: _groupNameFieldKey, currName: editGroup.groupName),
+                        SemYearField(fieldKey: _semYearFieldKey, currSemYear: editGroup.semYear),
+                        OwnerField(fieldKey: _ownerFieldKey, currOwner: editGroup.owner),
+                        GroupImageField(fieldKey: _groupImageFieldKey, currImage: editGroup.groupImage),
+                        GroupDescriptionField(fieldKey: _groupDescriptionFieldKey, currDesc: editGroup.groupDescription),
+                      ]
+                  ),
+                ),
+                Row(
+                    children: [
+                      SubmitButton(onSubmit: onSubmit),
+                      ResetButton(onReset: onReset),
+                    ]
+                )
+              ],
+            ),
+          ],
+        )
+    );
+  }
+}

--- a/lib/screens/groups_screen/form-fields/field_padding.dart
+++ b/lib/screens/groups_screen/form-fields/field_padding.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+/// Adds 5 pixels of padding around all fields.
+class FieldPadding extends StatelessWidget {
+  const FieldPadding({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(padding: const EdgeInsets.all(5.0), child: child);
+  }
+}

--- a/lib/screens/groups_screen/form-fields/group_description_field.dart
+++ b/lib/screens/groups_screen/form-fields/group_description_field.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_form_builder/flutter_form_builder.dart';
+import 'package:form_builder_validators/form_builder_validators.dart';
+
+import 'field_padding.dart';
+
+/// A text field to support defining new or revised garden names.
+class GroupDescriptionField extends StatelessWidget {
+  const GroupDescriptionField({super.key, required this.fieldKey, this.currDesc});
+
+  final String? currDesc;
+  final GlobalKey<FormBuilderFieldState<FormBuilderField<dynamic>, dynamic>>
+  fieldKey;
+
+  @override
+  Widget build(BuildContext context) {
+    String fieldName = 'Group Description (Optional)';
+    return FieldPadding(
+      child: FormBuilderTextField(
+        name: fieldName,
+        key: fieldKey,
+        initialValue: currDesc,
+        decoration: InputDecoration(
+          labelText: fieldName,
+          hintText: 'Example: "This group is created to study ..."',
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/groups_screen/form-fields/group_image_field.dart
+++ b/lib/screens/groups_screen/form-fields/group_image_field.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_form_builder/flutter_form_builder.dart';
+import 'package:form_builder_validators/form_builder_validators.dart';
+
+import 'field_padding.dart';
+
+/// A text field to support defining new or revised garden names.
+class GroupImageField extends StatelessWidget {
+  const GroupImageField({super.key, required this.fieldKey, this.currImage});
+
+  final String? currImage;
+  final GlobalKey<FormBuilderFieldState<FormBuilderField<dynamic>, dynamic>>
+  fieldKey;
+
+  @override
+  Widget build(BuildContext context) {
+    String fieldName = 'Group Image (Optional)';
+    return FieldPadding(
+      child: FormBuilderTextField(
+        name: fieldName,
+        key: fieldKey,
+        initialValue: currImage,
+        decoration: InputDecoration(
+          labelText: fieldName,
+          hintText: 'Example: "group-00X.png"',
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/groups_screen/form-fields/group_name_field.dart
+++ b/lib/screens/groups_screen/form-fields/group_name_field.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_form_builder/flutter_form_builder.dart';
+import 'package:form_builder_validators/form_builder_validators.dart';
+
+import 'field_padding.dart';
+
+/// A text field to support defining new or revised garden names.
+class GroupNameField extends StatelessWidget {
+  const GroupNameField({super.key, required this.fieldKey, this.currName});
+
+  final String? currName;
+  final GlobalKey<FormBuilderFieldState<FormBuilderField<dynamic>, dynamic>>
+  fieldKey;
+
+  @override
+  Widget build(BuildContext context) {
+    String fieldName = 'Group Name';
+    return FieldPadding(
+      child: FormBuilderTextField(
+        name: fieldName,
+        key: fieldKey,
+        initialValue: currName,
+        decoration: InputDecoration(
+          labelText: fieldName,
+          hintText: 'Example: "JPN 102"',
+        ),
+        validator: FormBuilderValidators.compose([
+          FormBuilderValidators.required(),
+        ]),
+      ),
+    );
+  }
+}

--- a/lib/screens/groups_screen/form-fields/owner_field.dart
+++ b/lib/screens/groups_screen/form-fields/owner_field.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_form_builder/flutter_form_builder.dart';
+import 'package:form_builder_validators/form_builder_validators.dart';
+
+import 'field_padding.dart';
+
+/// A text field to support defining new or revised garden names.
+class OwnerField extends StatelessWidget {
+  const OwnerField({super.key, required this.fieldKey, this.currOwner});
+
+  final String? currOwner;
+  final GlobalKey<FormBuilderFieldState<FormBuilderField<dynamic>, dynamic>>
+  fieldKey;
+
+  @override
+  Widget build(BuildContext context) {
+    String fieldName = 'Owner';
+    return FieldPadding(
+      child: FormBuilderTextField(
+        name: fieldName,
+        key: fieldKey,
+        initialValue: currOwner,
+        decoration: InputDecoration(
+          labelText: fieldName,
+          hintText: 'Example: "Professor Adams"',
+        ),
+        validator: FormBuilderValidators.compose([
+          FormBuilderValidators.required(),
+        ]),
+      ),
+    );
+  }
+}

--- a/lib/screens/groups_screen/form-fields/reset_button.dart
+++ b/lib/screens/groups_screen/form-fields/reset_button.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+import 'field_padding.dart';
+
+class ResetButton extends StatelessWidget {
+  const ResetButton({super.key, required this.onReset});
+
+  final void Function() onReset;
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: FieldPadding(
+        child: OutlinedButton(
+          onPressed: onReset,
+          child: Text('Reset',
+              style: TextStyle(color: Theme.of(context).colorScheme.secondary)),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/groups_screen/form-fields/semyear_field.dart
+++ b/lib/screens/groups_screen/form-fields/semyear_field.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_form_builder/flutter_form_builder.dart';
+import 'package:form_builder_validators/form_builder_validators.dart';
+
+import 'field_padding.dart';
+
+/// A text field to support defining new or revised garden names.
+class SemYearField extends StatelessWidget {
+  const SemYearField({super.key, required this.fieldKey, this.currSemYear});
+
+  final String? currSemYear;
+  final GlobalKey<FormBuilderFieldState<FormBuilderField<dynamic>, dynamic>>
+  fieldKey;
+
+  @override
+  Widget build(BuildContext context) {
+    String fieldSemYear = 'Semester & Year';
+    return FieldPadding(
+      child: FormBuilderTextField(
+        name: fieldSemYear,
+        key: fieldKey,
+        initialValue: currSemYear,
+        decoration: InputDecoration(
+          labelText: fieldSemYear,
+          hintText: 'Example: "Fall 2024"',
+        ),
+        validator: FormBuilderValidators.compose([
+          FormBuilderValidators.required(),
+        ]),
+      ),
+    );
+  }
+}

--- a/lib/screens/groups_screen/form-fields/submit_button.dart
+++ b/lib/screens/groups_screen/form-fields/submit_button.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+import 'field_padding.dart';
+
+class SubmitButton extends StatelessWidget {
+  const SubmitButton({super.key, required this.onSubmit});
+
+  final void Function() onSubmit;
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: FieldPadding(
+        child: ElevatedButton(
+          onPressed: onSubmit,
+          child: const Text(
+            'Submit',
+            style: TextStyle(color: Colors.white),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/groups_screen/groupinfo.dart
+++ b/lib/screens/groups_screen/groupinfo.dart
@@ -2,8 +2,9 @@ import 'package:connectuni/components/group_member_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:connectuni/model/group.dart';
-import '../model/group_list.dart';
-import '../model/user_list.dart';
+import '../../model/group_list.dart';
+import '../../model/user_list.dart';
+import 'edit_group.dart';
 
 /// Information page for a specific group that displays the group members as well as a description of the selected group.
 /// There is an icon at the upper right-hand corner for more statistic-related properties of the group.
@@ -102,20 +103,39 @@ class _GroupInfoState extends ConsumerState<GroupInfo> {
             Padding(
               padding: const EdgeInsets.all(10.0),
               //TODO: Make this button conditional on whether or not the user is in the group.
-              child: TextButton(
-                onPressed: () {
-                  //Remove the user from the group's database. Then Refresh the group's database.
-                  groupData.removeUserId(currentUser);
-                  //TODO: Remove groupId from user.
-                  ref.refresh(groupsDBProvider);
-                },
-                style: ButtonStyle(
-                  backgroundColor: MaterialStateProperty.all<Color>(Colors.red),
-                  foregroundColor:
-                      MaterialStateProperty.all<Color>(Colors.white),
-                ),
-                child: const Text('LEAVE THIS GROUP'),
-              ),
+              child:
+                Column(
+                  children: [
+                    TextButton(
+                      onPressed: () {
+                        Navigator.push(
+                            context, MaterialPageRoute(builder: (context) {
+                          return EditGroup(id: widget.id);
+                        }));
+                      },
+                      style: ButtonStyle(
+                        backgroundColor: MaterialStateProperty.all<Color>(Colors.lightBlueAccent),
+                        foregroundColor:
+                        MaterialStateProperty.all<Color>(Colors.white),
+                      ),
+                      child: const Text('EDIT THIS GROUP'),
+                    ),
+                    TextButton(
+                      onPressed: () {
+                        //Remove the user from the group's database. Then Refresh the group's database.
+                        groupData.removeUserId(currentUser);
+                        //TODO: Remove groupId from user.
+                        ref.refresh(groupsDBProvider);
+                      },
+                      style: ButtonStyle(
+                        backgroundColor: MaterialStateProperty.all<Color>(Colors.red),
+                        foregroundColor:
+                        MaterialStateProperty.all<Color>(Colors.white),
+                      ),
+                      child: const Text('LEAVE THIS GROUP'),
+                    ),
+                  ]
+                )
             ),
           //Display a button to join the group if the user is not in the group.
           if (!groupData.userIDs.contains(currentUser))

--- a/lib/screens/groups_screen/search_groups_screen.dart
+++ b/lib/screens/groups_screen/search_groups_screen.dart
@@ -3,10 +3,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:multi_select_flutter/multi_select_flutter.dart';
 
-import '../components/group_card_view.dart';
 import 'package:connectuni/utils/global_variables.dart';
-import '../components/group_chat_widget.dart';
-import '../model/group_list.dart';
+import '../../components/group_info_widget.dart';
+import '../../model/group_list.dart';
+import 'add_group.dart';
 
 class SearchGroupsScreen extends ConsumerStatefulWidget {
   const SearchGroupsScreen({Key? key, required this.pageController})
@@ -141,10 +141,39 @@ class _SearchGroupsScreenState extends ConsumerState<SearchGroupsScreen> {
               child: ListView.builder(
                 itemCount: groups.length,
                 itemBuilder: (context, index) {
-                  return GroupChatWidget(id: groups[index].groupID);
+                  return GroupInfoWidget(id: groups[index].groupID);
                 },
               )
           ),
+          Padding(
+            padding: EdgeInsets.all(8.0),
+            child:
+                Column(
+                  children: [
+                    const Text(
+                      "Can't find what you're looking for? Create a new group!"
+                    ),
+                    Padding(
+                      padding: EdgeInsets.all(10.0),
+                      child: ListTile(
+                        title: const Center(
+                            child: Text("Add a Group.",
+                                style: TextStyle(fontWeight: FontWeight.bold))),
+                        textColor: Colors.white,
+                        tileColor: Colors.black54,
+                        onTap: () {
+                          Navigator.push(
+                              context, MaterialPageRoute(builder: (context) {
+                            return AddGroup();
+                          }));
+                        }
+                      ),
+                    ),
+                  ],
+                ),
+
+          ),
+
         ],
       ),
     );

--- a/lib/screens/other_user_profile.dart
+++ b/lib/screens/other_user_profile.dart
@@ -23,6 +23,7 @@ class OtherUserProfile extends ConsumerWidget {
     final UserList usersDB = ref.read(userDBProvider);
     User thisUser = usersDB.getUserByID(uid);
     final User currentUser = usersDB.getUserByID(ref.read(currentUserProvider));
+    final GroupList groupsDB = ref.watch(groupsDBProvider);
     return Scaffold(
       appBar: AppBar(
         title: Text(user.displayName),
@@ -159,7 +160,7 @@ class OtherUserProfile extends ConsumerWidget {
                     ),
                       Column(
                         children: [
-                          ...TempGroupsDB
+                          ...groupsDB
                               .getGroupsByUser(user.uid)
                               .map((group) =>
                               Card(

--- a/lib/screens/search_groups_screen.dart
+++ b/lib/screens/search_groups_screen.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:multi_select_flutter/multi_select_flutter.dart';
-
 import '../components/group_card_view.dart';
 import '../model/group_list.dart';
 
-class SearchGroupsScreen extends StatefulWidget {
+class SearchGroupsScreen extends ConsumerStatefulWidget {
   const SearchGroupsScreen({Key? key, required this.pageController})
       : super(key: key);
 
@@ -12,17 +12,18 @@ class SearchGroupsScreen extends StatefulWidget {
   final PageController pageController;
 
   @override
-  State<SearchGroupsScreen> createState() => _SearchGroupsScreenState();
+  ConsumerState<SearchGroupsScreen> createState() => _SearchGroupsScreenState();
 }
 
-class _SearchGroupsScreenState extends State<SearchGroupsScreen> {
-  final _items = TempGroupsDB
-      .getAllGroups()
-      .map((gName) => MultiSelectItem(gName, gName.groupName))
-      .toList();
+class _SearchGroupsScreenState extends ConsumerState<SearchGroupsScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final GroupList groupsDB = ref.watch(groupsDBProvider);
+    final _items = groupsDB
+        .getAllGroups()
+        .map((gName) => MultiSelectItem(gName, gName.groupName))
+        .toList();
     return Scaffold(
       appBar: AppBar(
         title: const Text('Search for Groups'),
@@ -118,14 +119,14 @@ class _SearchGroupsScreenState extends State<SearchGroupsScreen> {
               'RelatedCourses/Groups',
               textAlign: TextAlign.left,
             ),
-            ...TempGroupsDB
+            ...groupsDB
                 .getAllGroups()
                 .map((gName) => GroupCardView(id: gName.groupID)),
             const Text(
               'Other Groups',
               textAlign: TextAlign.left,
             ),
-            ...TempGroupsDB
+            ...groupsDB
                 .getAllGroups()
                 .map((gName) => GroupCardView(id: gName.groupID)),
             const Text('Events'),

--- a/lib/screens/search_people_screen.dart
+++ b/lib/screens/search_people_screen.dart
@@ -24,7 +24,8 @@ class _SearchPeopleScreenState extends ConsumerState<SearchPeopleScreen> {
   Widget build(BuildContext context) {
     final UserList usersDB = ref.read(userDBProvider);
     final User currentUser = usersDB.getUserByID(ref.read(currentUserProvider));
-    final _items = TempGroupsDB
+    final GroupList groupsDB = ref.watch(groupsDBProvider);
+    final _items = groupsDB
         .getAllGroups()
         .map((gName) => MultiSelectItem(gName, gName.groupName))
         .toList();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -102,6 +102,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_form_builder:
+    dependency: "direct main"
+    description:
+      name: flutter_form_builder
+      sha256: "8973beed34b6d951d36bf688b52e9e3040b47b763c35c320bd6f4c2f6b13f3a2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.1.1"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -110,6 +118,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.3"
+  flutter_localizations:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_native_splash:
     dependency: "direct main"
     description:
@@ -136,6 +149,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  form_builder_validators:
+    dependency: "direct main"
+    description:
+      name: form_builder_validators
+      sha256: "19aa5282b7cede82d0025ab031a98d0554b84aa2ba40f12013471a3b3e22bf02"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.1.0"
   html:
     dependency: transitive
     description:
@@ -367,4 +388,4 @@ packages:
     version: "3.1.2"
 sdks:
   dart: ">=3.1.2 <4.0.0"
-  flutter: ">=3.0.0"
+  flutter: ">=3.10.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,8 @@ dependencies:
   flutter_native_splash:
   table_calendar: ^3.0.9
   flutter_riverpod: ^2.3.6
+  flutter_form_builder: ">=7.7.0"
+  form_builder_validators: ">=8.4.0"
 
 
   # The following adds the Cupertino Icons font to your application.


### PR DESCRIPTION
There are a lot of updates in this pull request, notably:

- Created AddGroup.dart and EditGroup.dart
- Search Groups page now links directly to the group info page rather than the group chat page.
- Search Groups page now has an "add group" button that links to the add group page.
- Group Info Page now has an "edit group" button that can be accessed iff the currentuser is in the group (should change this later to only be editable by the group owner)
- Group Join and Group Leave buttons now work on the Group Info and Current User Profile page.