### PR TITLE
Add route to search groups screen

### DIFF
--- a/lib/features/group/presentation/groups_screen.dart
+++ b/lib/features/group/presentation/groups_screen.dart
@@ -1,4 +1,3 @@
-import 'package:connectuni/features/group/presentation/search_groups_screen.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:connectuni/features/group/presentation/group_chat_widget.dart';

--- a/lib/features/group/presentation/groups_screen.dart
+++ b/lib/features/group/presentation/groups_screen.dart
@@ -1,16 +1,13 @@
-import 'package:connectuni/features/group/presentation/add_group.dart';
 import 'package:connectuni/features/group/presentation/search_groups_screen.dart';
-import 'package:connectuni/features/home/presentation/search_page_controller.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:connectuni/features/group/presentation/group_chat_widget.dart';
 import 'package:flutter/material.dart';
-import '../../home/presentation/home.dart';
 import '../../user/data/user_providers.dart';
 import '../data/group_providers.dart';
 import '../domain/group_list.dart';
-import '../../user/domain/user_list.dart';
 import '../../chat/presentation/chatpage.dart';
+import 'add_group.dart';
 
 class GroupsScreen extends ConsumerStatefulWidget {
   const GroupsScreen({Key? key}) : super(key: key);
@@ -63,12 +60,9 @@ class _GroupsScreenState extends ConsumerState<GroupsScreen> {
             padding: const EdgeInsets.only(bottom: 10.0),
             child: IconButton(
               onPressed: () {
-                Navigator.pushReplacement(
-                  context,
-                  CupertinoPageRoute(
-                      builder: (context) =>
-                          SearchGroupsScreen(pageController: _pageController)),
-                );
+                Navigator.push(context, MaterialPageRoute(builder: (context) {
+                  return AddGroup();
+                }));
               },
               icon: const Icon(
                 Icons.add_circle_outline,

--- a/lib/features/group/presentation/groups_screen.dart
+++ b/lib/features/group/presentation/groups_screen.dart
@@ -1,6 +1,11 @@
+import 'package:connectuni/features/group/presentation/add_group.dart';
+import 'package:connectuni/features/group/presentation/search_groups_screen.dart';
+import 'package:connectuni/features/home/presentation/search_page_controller.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:connectuni/features/group/presentation/group_chat_widget.dart';
 import 'package:flutter/material.dart';
+import '../../home/presentation/home.dart';
 import '../../user/data/user_providers.dart';
 import '../data/group_providers.dart';
 import '../domain/group_list.dart';
@@ -19,6 +24,8 @@ class _GroupsScreenState extends ConsumerState<GroupsScreen> {
   Widget build(BuildContext context) {
     final GroupList groupsDB = ref.watch(groupsDBProvider);
     final String userId = ref.watch(currentUserProvider);
+    late PageController _pageController;
+    _pageController = PageController();
     return Scaffold(
       appBar: AppBar(
         title: const Text('My Groups'),
@@ -51,20 +58,25 @@ class _GroupsScreenState extends ConsumerState<GroupsScreen> {
           ...groupsDB
               .getGroupsByUser(userId)
               .map((gName) => GroupChatWidget(id: gName.groupID)),
-          const Center(
-            child:
-            Padding(
-              padding: EdgeInsets.only(bottom: 10.0),
-              child: IconButton(
-                onPressed: null,
-                icon: Icon(
-                  Icons.add_circle_outline,
-                  color: Colors.grey,
-                  size: 40.0,
-                ),
+          Center(
+              child: Padding(
+            padding: const EdgeInsets.only(bottom: 10.0),
+            child: IconButton(
+              onPressed: () {
+                Navigator.pushReplacement(
+                  context,
+                  CupertinoPageRoute(
+                      builder: (context) =>
+                          SearchGroupsScreen(pageController: _pageController)),
+                );
+              },
+              icon: const Icon(
+                Icons.add_circle_outline,
+                color: Colors.grey,
+                size: 40.0,
               ),
-            )
-          ),
+            ),
+          )),
         ],
       ),
     );


### PR DESCRIPTION
The "plus-circle" button at the bottom of the home page (all the user's groups) now routes to the Add Group page.